### PR TITLE
change response type for searchChannels to ChannelResponse

### DIFF
--- a/src/neynar-api/neynar-api-client.ts
+++ b/src/neynar-api/neynar-api-client.ts
@@ -2107,7 +2107,7 @@ export class NeynarAPIClient {
    *
    * @param {string} q - The query string used for searching channels, which can be a channel ID or name.
    *
-   * @returns {Promise<ChannelListResponse>} A promise that resolves to a `ChannelListResponse` object,
+   * @returns {Promise<ChannelResponse>} A promise that resolves to a `ChannelListResponse` object,
    *   containing a list of channels that match the search criteria.
    *
    * @example
@@ -2118,7 +2118,7 @@ export class NeynarAPIClient {
    *
    * For more information, refer to the [Neynar documentation](https://docs.neynar.com/reference/search-channels).
    */
-  public async searchChannels(q: string): Promise<ChannelListResponse> {
+  public async searchChannels(q: string): Promise<ChannelResponse> {
     return await this.clients.v2.searchChannels(q);
   }
 

--- a/src/neynar-api/v2/client.ts
+++ b/src/neynar-api/v2/client.ts
@@ -1851,7 +1851,7 @@ export class NeynarV2APIClient {
    *
    * @param {string} q - The query string used for searching channels, which can be a channel ID or name.
    *
-   * @returns {Promise<ChannelListResponse>} A promise that resolves to a `ChannelListResponse` object,
+   * @returns {Promise<ChannelResponse>} A promise that resolves to a `ChannelListResponse` object,
    *   containing a list of channels that match the search criteria.
    *
    * @example
@@ -1862,7 +1862,7 @@ export class NeynarV2APIClient {
    *
    * For more information, refer to the [Neynar documentation](https://docs.neynar.com/reference/search-channels).
    */
-  public async searchChannels(q: string): Promise<ChannelListResponse> {
+  public async searchChannels(q: string): Promise<ChannelResponse> {
     const response = await this.apis.channel.searchChannels(this.apiKey, q);
     return response.data;
   }

--- a/src/neynar-api/v2/openapi-farcaster/apis/channel-api.ts
+++ b/src/neynar-api/v2/openapi-farcaster/apis/channel-api.ts
@@ -559,7 +559,7 @@ export const ChannelApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async searchChannels(apiKey: string, q: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ChannelListResponse>> {
+        async searchChannels(apiKey: string, q: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ChannelResponse>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.searchChannels(apiKey, q, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
@@ -676,7 +676,7 @@ export const ChannelApiFactory = function (configuration?: Configuration, basePa
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        searchChannels(apiKey: string, q: string, options?: any): AxiosPromise<ChannelListResponse> {
+        searchChannels(apiKey: string, q: string, options?: any): AxiosPromise<ChannelResponse> {
             return localVarFp.searchChannels(apiKey, q, options).then((request) => request(axios, basePath));
         },
         /**


### PR DESCRIPTION
Update

searchChannels -> https://docs.neynar.com/reference/search-channels
now has type ChannelResponse returned