### PR TITLE
fix: v1 to v2 user converter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neynar/nodejs-sdk",
-  "version": "1.41.2",
+  "version": "1.41.3",
   "description": "SDK to interact with Neynar APIs (https://docs.neynar.com/)",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/src/neynar-api/common/version.ts
+++ b/src/neynar-api/common/version.ts
@@ -1,1 +1,1 @@
-export const version = "1.41.2";
+export const version = "1.41.3";

--- a/src/neynar-api/utils/v1-to-v2-converters.ts
+++ b/src/neynar-api/utils/v1-to-v2-converters.ts
@@ -33,8 +33,10 @@ export const convertToV2User = (v1User: IUserV1): IUserV2 => {
         : ActiveStatus.Inactive,
     ...(v1User.viewerContext
       ? {
-          following: v1User.viewerContext.following,
-          followed_by: v1User.viewerContext.followedBy,
+         viewer_context: {
+           following: v1User.viewerContext.following,
+           followed_by: v1User.viewerContext.followedBy,
+         }
         }
       : {}),
   };


### PR DESCRIPTION
The `following` and `followed_by` properties needed to be inside `viewer_context`. In the previous code, they were spread at the top level 