### PR TITLE
feat: `searchCasts` now takes `viewerFid` so that it can return the viewer context

### DIFF
--- a/src/neynar-api/neynar-api-client.ts
+++ b/src/neynar-api/neynar-api-client.ts
@@ -1571,6 +1571,7 @@ export class NeynarAPIClient {
    * @param {string} q - The query string used for searching users.
    * @param {Object} [options] - Optional parameters for the cast.
    * @param {number} [options.authorFid] - Optional fid of the user to search casts for.
+   * @param {number} [options.viewerFid] Fid of the viewer of the casts, used to show viewer_context
    * @param {string} [options.parentUrl] - Optional parent url to search casts for.
    * @param {string} [options.channelId] - Optional channel to search casts for.
    * @param {number} [options.limit] - Number of results to retrieve (default 25, max 100)
@@ -1591,6 +1592,7 @@ export class NeynarAPIClient {
     q: string,
     options?: {
       authorFid?: number;
+      viewerFid?: number;
       parentUrl?: string;
       channelId?: string;
       limit?: number;

--- a/src/neynar-api/v2/client.ts
+++ b/src/neynar-api/v2/client.ts
@@ -1147,6 +1147,7 @@ export class NeynarV2APIClient {
    * @param {string} q - The query string used for searching users.
    * @param {Object} [options] - Optional parameters for the cast.
    * @param {number} [options.authorFid] - Optional fid of the user to search casts for.
+   * @param {number} [options.viewerFid] Fid of the viewer of the casts, used to show viewer_context
    * @param {string} [options.channelId] - Optional channel to search casts for.
    * @param {string} [options.parentUrl] - Optional parent url to search casts for.
    * @param {number} [options.limit] - Number of results to retrieve (default 25, max 100)
@@ -1167,6 +1168,7 @@ export class NeynarV2APIClient {
     q: string,
     options?: {
       authorFid?: number;
+      viewerFid?: number;
       parentUrl?: string;
       channelId?: string;
       limit?: number;
@@ -1177,6 +1179,7 @@ export class NeynarV2APIClient {
       this.apiKey,
       q,
       options?.authorFid,
+      options?.viewerFid,
       options?.parentUrl,
       options?.channelId,
       options?.limit,

--- a/src/neynar-api/v2/openapi-farcaster/apis/cast-api.ts
+++ b/src/neynar-api/v2/openapi-farcaster/apis/cast-api.ts
@@ -189,6 +189,7 @@ export const CastApiAxiosParamCreator = function (configuration?: Configuration)
          * @param {string} apiKey API key required for authentication.
          * @param {string} q Query string to search for casts
          * @param {number} [authorFid] Fid of the user whose casts you want to search
+         * @param {number} [viewerFid] Fid of the viewer of the casts, used to show viewer_context
          * @param {string} [parentUrl] Parent URL of the casts you want to search
          * @param {string} [channelId] Channel ID of the casts you want to search
          * @param {number} [limit] 
@@ -196,7 +197,7 @@ export const CastApiAxiosParamCreator = function (configuration?: Configuration)
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        castSearch: async (apiKey: string, q: string, authorFid?: number, parentUrl?: string, channelId?: string, limit?: number, cursor?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        castSearch: async (apiKey: string, q: string, authorFid?: number, viewerFid?: number, parentUrl?: string, channelId?: string, limit?: number, cursor?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'apiKey' is not null or undefined
             assertParamExists('castSearch', 'apiKey', apiKey)
             // verify required parameter 'q' is not null or undefined
@@ -219,6 +220,10 @@ export const CastApiAxiosParamCreator = function (configuration?: Configuration)
 
             if (authorFid !== undefined) {
                 localVarQueryParameter['author_fid'] = authorFid;
+            }
+
+            if (viewerFid !== undefined) {
+                localVarQueryParameter['viewer_fid'] = viewerFid;
             }
 
             if (parentUrl !== undefined) {
@@ -494,6 +499,7 @@ export const CastApiFp = function(configuration?: Configuration) {
          * @param {string} apiKey API key required for authentication.
          * @param {string} q Query string to search for casts
          * @param {number} [authorFid] Fid of the user whose casts you want to search
+         * @param {number} [viewerFid] Fid of the viewer of the casts, used to show viewer_context
          * @param {string} [parentUrl] Parent URL of the casts you want to search
          * @param {string} [channelId] Channel ID of the casts you want to search
          * @param {number} [limit] 
@@ -501,8 +507,8 @@ export const CastApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async castSearch(apiKey: string, q: string, authorFid?: number, parentUrl?: string, channelId?: string, limit?: number, cursor?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<CastsSearchResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.castSearch(apiKey, q, authorFid, parentUrl, channelId, limit, cursor, options);
+        async castSearch(apiKey: string, q: string, authorFid?: number, viewerFid?: number, parentUrl?: string, channelId?: string, limit?: number, cursor?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<CastsSearchResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.castSearch(apiKey, q, authorFid, viewerFid, parentUrl, channelId, limit, cursor, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -603,6 +609,7 @@ export const CastApiFactory = function (configuration?: Configuration, basePath?
          * @param {string} apiKey API key required for authentication.
          * @param {string} q Query string to search for casts
          * @param {number} [authorFid] Fid of the user whose casts you want to search
+         * @param {number} [viewerFid] Fid of the viewer of the casts, used to show viewer_context
          * @param {string} [parentUrl] Parent URL of the casts you want to search
          * @param {string} [channelId] Channel ID of the casts you want to search
          * @param {number} [limit] 
@@ -610,8 +617,8 @@ export const CastApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        castSearch(apiKey: string, q: string, authorFid?: number, parentUrl?: string, channelId?: string, limit?: number, cursor?: string, options?: any): AxiosPromise<CastsSearchResponse> {
-            return localVarFp.castSearch(apiKey, q, authorFid, parentUrl, channelId, limit, cursor, options).then((request) => request(axios, basePath));
+        castSearch(apiKey: string, q: string, authorFid?: number, viewerFid?: number, parentUrl?: string, channelId?: string, limit?: number, cursor?: string, options?: any): AxiosPromise<CastsSearchResponse> {
+            return localVarFp.castSearch(apiKey, q, authorFid, viewerFid, parentUrl, channelId, limit, cursor, options).then((request) => request(axios, basePath));
         },
         /**
          * Retrieve multiple casts using their respective hashes.
@@ -711,6 +718,7 @@ export class CastApi extends BaseAPI {
      * @param {string} apiKey API key required for authentication.
      * @param {string} q Query string to search for casts
      * @param {number} [authorFid] Fid of the user whose casts you want to search
+     * @param {number} [viewerFid] Fid of the viewer of the casts, used to show viewer_context
      * @param {string} [parentUrl] Parent URL of the casts you want to search
      * @param {string} [channelId] Channel ID of the casts you want to search
      * @param {number} [limit] 
@@ -719,8 +727,8 @@ export class CastApi extends BaseAPI {
      * @throws {RequiredError}
      * @memberof CastApi
      */
-    public castSearch(apiKey: string, q: string, authorFid?: number, parentUrl?: string, channelId?: string, limit?: number, cursor?: string, options?: AxiosRequestConfig) {
-        return CastApiFp(this.configuration).castSearch(apiKey, q, authorFid, parentUrl, channelId, limit, cursor, options).then((request) => request(this.axios, this.basePath));
+    public castSearch(apiKey: string, q: string, authorFid?: number, viewerFid?: number, parentUrl?: string, channelId?: string, limit?: number, cursor?: string, options?: AxiosRequestConfig) {
+        return CastApiFp(this.configuration).castSearch(apiKey, q, authorFid, viewerFid, parentUrl, channelId, limit, cursor, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**


### PR DESCRIPTION
## Example

```
# index.js
const result = await client.searchCasts("wowow", {viewerFid: 489795, limit: 3});
console.log(JSON.stringify(result));
```

```
$ node index.js | jq '.result.casts[] | {text: .text, author: {fid: .author.fid, viewer_context: .author.viewer_context}, viewer_context: .viewer_context}'

{
  "text": "Whether you're in 'founder mode' or 'manager mode', you need to make sure your marketing team understands your product.\n\nThis will help you 👇 \nhttps://mirror.xyz/cryptotaboo.eth/wq--HTfY22a36LpO_XdVJ-qCj_yzMt73-tZMoDNeuMk",
  "author": {
    "fid": 308042,
    "viewer_context": {
      "following": false,
      "followed_by": false
    }
  },
  "viewer_context": {
    "liked": false,
    "recasted": false
  }
}
{
  "text": "founder mode just turned off...",
  "author": {
    "fid": 408262,
    "viewer_context": {
      "following": false,
      "followed_by": false
    }
  },
  "viewer_context": {
    "liked": false,
    "recasted": false
  }
}
{
  "text": "Yeah this doesn’t feel groundbreaking— founder mode has always been a thing we just didn’t have this name for it. \n\nThere’s also plenty of examples of founders who wouldn’t give up power/micromanage and that also doesn’t work well for scaling. \n\nI would love to see some research/dara that shows what the actual results are for different approaches so if that results for this interest then great!",
  "author": {
    "fid": 4167,
    "viewer_context": {
      "following": false,
      "followed_by": false
    }
  },
  "viewer_context": {
    "liked": false,
    "recasted": false
  }
}
```
