### PR TITLE
feat: add priority mode for notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neynar/nodejs-sdk",
-  "version": "1.52.1",
+  "version": "1.53.0",
   "description": "SDK to interact with Neynar APIs (https://docs.neynar.com/)",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/src/neynar-api/common/version.ts
+++ b/src/neynar-api/common/version.ts
@@ -1,1 +1,1 @@
-export const version = "1.52.1";
+export const version = "1.53.0";

--- a/src/neynar-api/neynar-api-client.ts
+++ b/src/neynar-api/neynar-api-client.ts
@@ -2228,6 +2228,7 @@ export class NeynarAPIClient {
    * @param {Object} [options] - Optional parameters to tailor the request.
    * @param {boolean} [options.isPriority] - Whether to include only priority notifications in the response.
    *   This parameter is deprecated and will be removed in the next major release.
+   * @param {boolean} [options.priorityMode] When true, only returns notifications from power badge users and users that the viewer follows.
    * @param @param {'follows' | 'recasts' | 'likes' | 'mentions' | 'replies'} [options.type] Notification type to fetch.
    * @param {string} [options.cursor] - A pagination cursor for fetching specific subsets of results.
    *   Omit this parameter for the initial request. Use it for paginated retrieval of subsequent data.
@@ -2251,6 +2252,7 @@ export class NeynarAPIClient {
       cursor?: string;
       type?: "follows" | "recasts" | "likes" | "mentions" | "replies";
       isPriority?: boolean;
+      priorityMode?: boolean;
     }
   ): Promise<NotificationsResponse> {
     return await this.clients.v2.fetchAllNotifications(fid, options);
@@ -2266,6 +2268,7 @@ export class NeynarAPIClient {
    * @param {Object} [options] - Optional parameters for the request.
    * @param {boolean} [options.isPriority] - Whether to include only priority notifications in the response.
    *   This parameter is deprecated and will be removed in the next major release.
+   * @param {boolean} [options.priorityMode] When true, only returns notifications from power badge users and users that the viewer follows.
    * @param {string} [options.cursor] - Pagination cursor for the next set of results,
    *   omit this parameter for the initial request.
    *
@@ -2286,7 +2289,7 @@ export class NeynarAPIClient {
   public async fetchChannelNotificationsForUser(
     fid: number,
     channelIds: string[],
-    options?: { cursor?: string; isPriority?: boolean }
+    options?: { cursor?: string; isPriority?: boolean; priorityMode?: boolean }
   ): Promise<NotificationsResponse> {
     return await this.clients.v2.fetchChannelNotificationsForUser(
       fid,
@@ -2523,6 +2526,7 @@ export class NeynarAPIClient {
    * @param {Object} [options] - Optional parameters for customizing the response.
    * @param {boolean} [options.isPriority] - Whether to include only priority notifications in the response.
    *   This parameter is deprecated and will be removed in the next major release.
+   * @param {boolean} [options.priorityMode] When true, only returns notifications from power badge users and users that the viewer follows.
    * @param {string} [options.cursor] - Pagination cursor for the next set of results,
    *   omit this parameter for the initial request.
    *
@@ -2540,7 +2544,7 @@ export class NeynarAPIClient {
   public async fetchNotificationsByParentUrlForUser(
     fid: number,
     parentUrls: string[],
-    options?: { cursor?: string; isPriority?: boolean }
+    options?: { cursor?: string; isPriority?: boolean, priorityMode?: boolean }
   ) {
     return await this.clients.v2.fetchNotificationsByParentUrlForUser(
       fid,

--- a/src/neynar-api/v2/client.ts
+++ b/src/neynar-api/v2/client.ts
@@ -1983,6 +1983,7 @@ export class NeynarV2APIClient {
    * @param {number} fid - The FID of the user whose notifications are being fetched.
    * @param {Object} [options] - Optional parameters to tailor the request.
    * @param {string} [options.type] - Type of notifications to fetch.
+   * @param {boolean} [options.priorityMode] When true, only returns notifications from power badge users and users that the viewer follows.
    * @param {string} [options.cursor] - Pagination cursor for the next set of results,
    *   omit this parameter for the initial request.
    *
@@ -2003,6 +2004,7 @@ export class NeynarV2APIClient {
     fid: number,
     options?: {
       type?: "follows" | "recasts" | "likes" | "mentions" | "replies";
+      priorityMode?: boolean;
       cursor?: string;
     }
   ): Promise<NotificationsResponse> {
@@ -2010,6 +2012,7 @@ export class NeynarV2APIClient {
       this.apiKey,
       fid,
       options?.type,
+      options?.priorityMode,
       options?.cursor
     );
     return response.data;
@@ -2023,6 +2026,7 @@ export class NeynarV2APIClient {
    * @param {number} fid - The FID of the user whose channel notifications are being fetched.
    * @param {string} channelIds - channel_ids (find list of all channels here - https://docs.neynar.com/reference/list-all-channels)
    * @param {Object} [options] - Optional parameters for the request.
+   * @param {boolean} [options.priorityMode] When true, only returns notifications from power badge users and users that the viewer follows.
    * @param {string} [options.cursor] - Pagination cursor for the next set of results,
    *   omit this parameter for the initial request.
    *
@@ -2044,13 +2048,14 @@ export class NeynarV2APIClient {
   public async fetchChannelNotificationsForUser(
     fid: number,
     channelIds: string[],
-    options?: { cursor?: string }
+    options?: { priorityMode?: boolean; cursor?: string }
   ): Promise<NotificationsResponse> {
     const _channelIds = channelIds.join(",");
     const response = await this.apis.notifications.notificationsChannel(
       this.apiKey,
       fid,
       _channelIds,
+      options?.priorityMode,
       options?.cursor
     );
     return response.data;
@@ -2064,6 +2069,7 @@ export class NeynarV2APIClient {
    * @param {number} fid - The FID of the user for whom notifications are being fetched.
    * @param {Array<string>} parentUrls - An array of parent URLs to specify the channels.
    * @param {Object} [options] - Optional parameters for customizing the response.
+   * @param {boolean} [options.priorityMode] When true, only returns notifications from power badge users and users that the viewer follows.
    * @param {string} [options.cursor] - Pagination cursor for the next set of results,
    *   omit this parameter for the initial request.
    *
@@ -2081,13 +2087,14 @@ export class NeynarV2APIClient {
   public async fetchNotificationsByParentUrlForUser(
     fid: number,
     parentUrls: string[],
-    options?: { cursor?: string }
+    options?: { priorityMode?: boolean; cursor?: string }
   ) {
     const _parentUrls = parentUrls.join(",");
     const response = await this.apis.notifications.notificationsParentUrl(
       this.apiKey,
       fid,
       _parentUrls,
+      options?.priorityMode,
       options?.cursor
     );
     return response.data;

--- a/src/neynar-api/v2/openapi-farcaster/apis/notifications-api.ts
+++ b/src/neynar-api/v2/openapi-farcaster/apis/notifications-api.ts
@@ -86,11 +86,12 @@ export const NotificationsApiAxiosParamCreator = function (configuration?: Confi
          * @param {string} apiKey API key required for authentication.
          * @param {number} fid FID of the user you you want to fetch notifications for
          * @param {NotificationType} [type] Notification type to fetch.
+         * @param {boolean} [priorityMode] When true, only returns notifications from power badge users and users that the viewer follows.
          * @param {string} [cursor] Pagination cursor.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        notifications: async (apiKey: string, fid: number, type?: NotificationType, cursor?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        notifications: async (apiKey: string, fid: number, type?: NotificationType, priorityMode?: boolean, cursor?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'apiKey' is not null or undefined
             assertParamExists('notifications', 'apiKey', apiKey)
             // verify required parameter 'fid' is not null or undefined
@@ -113,6 +114,10 @@ export const NotificationsApiAxiosParamCreator = function (configuration?: Confi
 
             if (type !== undefined) {
                 localVarQueryParameter['type'] = type;
+            }
+
+            if (priorityMode !== undefined) {
+                localVarQueryParameter['priority_mode'] = priorityMode;
             }
 
             if (cursor !== undefined) {
@@ -140,11 +145,12 @@ export const NotificationsApiAxiosParamCreator = function (configuration?: Confi
          * @param {string} apiKey API key required for authentication.
          * @param {number} fid FID of the user you you want to fetch notifications for
          * @param {string} channelIds Comma separated channel_ids (find list of all channels here - https://docs.neynar.com/reference/list-all-channels)
+         * @param {boolean} [priorityMode] When true, only returns notifications from power badge users and users that the viewer follows.
          * @param {string} [cursor] Pagination cursor.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        notificationsChannel: async (apiKey: string, fid: number, channelIds: string, cursor?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        notificationsChannel: async (apiKey: string, fid: number, channelIds: string, priorityMode?: boolean, cursor?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'apiKey' is not null or undefined
             assertParamExists('notificationsChannel', 'apiKey', apiKey)
             // verify required parameter 'fid' is not null or undefined
@@ -169,6 +175,10 @@ export const NotificationsApiAxiosParamCreator = function (configuration?: Confi
 
             if (channelIds !== undefined) {
                 localVarQueryParameter['channel_ids'] = channelIds;
+            }
+
+            if (priorityMode !== undefined) {
+                localVarQueryParameter['priority_mode'] = priorityMode;
             }
 
             if (cursor !== undefined) {
@@ -196,11 +206,12 @@ export const NotificationsApiAxiosParamCreator = function (configuration?: Confi
          * @param {string} apiKey API key required for authentication.
          * @param {number} fid FID of the user you you want to fetch notifications for
          * @param {string} parentUrls Comma separated parent_urls
+         * @param {boolean} [priorityMode] When true, only returns notifications from power badge users and users that the viewer follows.
          * @param {string} [cursor] Pagination cursor.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        notificationsParentUrl: async (apiKey: string, fid: number, parentUrls: string, cursor?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        notificationsParentUrl: async (apiKey: string, fid: number, parentUrls: string, priorityMode?: boolean, cursor?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'apiKey' is not null or undefined
             assertParamExists('notificationsParentUrl', 'apiKey', apiKey)
             // verify required parameter 'fid' is not null or undefined
@@ -225,6 +236,10 @@ export const NotificationsApiAxiosParamCreator = function (configuration?: Confi
 
             if (parentUrls !== undefined) {
                 localVarQueryParameter['parent_urls'] = parentUrls;
+            }
+
+            if (priorityMode !== undefined) {
+                localVarQueryParameter['priority_mode'] = priorityMode;
             }
 
             if (cursor !== undefined) {
@@ -274,12 +289,13 @@ export const NotificationsApiFp = function(configuration?: Configuration) {
          * @param {string} apiKey API key required for authentication.
          * @param {number} fid FID of the user you you want to fetch notifications for
          * @param {NotificationType} [type] Notification type to fetch.
+         * @param {boolean} [priorityMode] When true, only returns notifications from power badge users and users that the viewer follows.
          * @param {string} [cursor] Pagination cursor.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async notifications(apiKey: string, fid: number, type?: NotificationType, cursor?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<NotificationsResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.notifications(apiKey, fid, type, cursor, options);
+        async notifications(apiKey: string, fid: number, type?: NotificationType, priorityMode?: boolean, cursor?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<NotificationsResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.notifications(apiKey, fid, type, priorityMode, cursor, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -288,12 +304,13 @@ export const NotificationsApiFp = function(configuration?: Configuration) {
          * @param {string} apiKey API key required for authentication.
          * @param {number} fid FID of the user you you want to fetch notifications for
          * @param {string} channelIds Comma separated channel_ids (find list of all channels here - https://docs.neynar.com/reference/list-all-channels)
+         * @param {boolean} [priorityMode] When true, only returns notifications from power badge users and users that the viewer follows.
          * @param {string} [cursor] Pagination cursor.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async notificationsChannel(apiKey: string, fid: number, channelIds: string, cursor?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<NotificationsResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.notificationsChannel(apiKey, fid, channelIds, cursor, options);
+        async notificationsChannel(apiKey: string, fid: number, channelIds: string, priorityMode?: boolean, cursor?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<NotificationsResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.notificationsChannel(apiKey, fid, channelIds, priorityMode, cursor, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -302,12 +319,13 @@ export const NotificationsApiFp = function(configuration?: Configuration) {
          * @param {string} apiKey API key required for authentication.
          * @param {number} fid FID of the user you you want to fetch notifications for
          * @param {string} parentUrls Comma separated parent_urls
+         * @param {boolean} [priorityMode] When true, only returns notifications from power badge users and users that the viewer follows.
          * @param {string} [cursor] Pagination cursor.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async notificationsParentUrl(apiKey: string, fid: number, parentUrls: string, cursor?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<NotificationsResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.notificationsParentUrl(apiKey, fid, parentUrls, cursor, options);
+        async notificationsParentUrl(apiKey: string, fid: number, parentUrls: string, priorityMode?: boolean, cursor?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<NotificationsResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.notificationsParentUrl(apiKey, fid, parentUrls, priorityMode, cursor, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -337,12 +355,13 @@ export const NotificationsApiFactory = function (configuration?: Configuration, 
          * @param {string} apiKey API key required for authentication.
          * @param {number} fid FID of the user you you want to fetch notifications for
          * @param {NotificationType} [type] Notification type to fetch.
+         * @param {boolean} [priorityMode] When true, only returns notifications from power badge users and users that the viewer follows.
          * @param {string} [cursor] Pagination cursor.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        notifications(apiKey: string, fid: number, type?: NotificationType, cursor?: string, options?: any): AxiosPromise<NotificationsResponse> {
-            return localVarFp.notifications(apiKey, fid, type, cursor, options).then((request) => request(axios, basePath));
+        notifications(apiKey: string, fid: number, type?: NotificationType, priorityMode?: boolean, cursor?: string, options?: any): AxiosPromise<NotificationsResponse> {
+            return localVarFp.notifications(apiKey, fid, type, priorityMode, cursor, options).then((request) => request(axios, basePath));
         },
         /**
          * Returns a list of notifications for a user in specific channels
@@ -350,12 +369,13 @@ export const NotificationsApiFactory = function (configuration?: Configuration, 
          * @param {string} apiKey API key required for authentication.
          * @param {number} fid FID of the user you you want to fetch notifications for
          * @param {string} channelIds Comma separated channel_ids (find list of all channels here - https://docs.neynar.com/reference/list-all-channels)
+         * @param {boolean} [priorityMode] When true, only returns notifications from power badge users and users that the viewer follows.
          * @param {string} [cursor] Pagination cursor.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        notificationsChannel(apiKey: string, fid: number, channelIds: string, cursor?: string, options?: any): AxiosPromise<NotificationsResponse> {
-            return localVarFp.notificationsChannel(apiKey, fid, channelIds, cursor, options).then((request) => request(axios, basePath));
+        notificationsChannel(apiKey: string, fid: number, channelIds: string, priorityMode?: boolean, cursor?: string, options?: any): AxiosPromise<NotificationsResponse> {
+            return localVarFp.notificationsChannel(apiKey, fid, channelIds, priorityMode, cursor, options).then((request) => request(axios, basePath));
         },
         /**
          * Returns a list of notifications for a user in specific parent_urls
@@ -363,12 +383,13 @@ export const NotificationsApiFactory = function (configuration?: Configuration, 
          * @param {string} apiKey API key required for authentication.
          * @param {number} fid FID of the user you you want to fetch notifications for
          * @param {string} parentUrls Comma separated parent_urls
+         * @param {boolean} [priorityMode] When true, only returns notifications from power badge users and users that the viewer follows.
          * @param {string} [cursor] Pagination cursor.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        notificationsParentUrl(apiKey: string, fid: number, parentUrls: string, cursor?: string, options?: any): AxiosPromise<NotificationsResponse> {
-            return localVarFp.notificationsParentUrl(apiKey, fid, parentUrls, cursor, options).then((request) => request(axios, basePath));
+        notificationsParentUrl(apiKey: string, fid: number, parentUrls: string, priorityMode?: boolean, cursor?: string, options?: any): AxiosPromise<NotificationsResponse> {
+            return localVarFp.notificationsParentUrl(apiKey, fid, parentUrls, priorityMode, cursor, options).then((request) => request(axios, basePath));
         },
     };
 };
@@ -399,13 +420,14 @@ export class NotificationsApi extends BaseAPI {
      * @param {string} apiKey API key required for authentication.
      * @param {number} fid FID of the user you you want to fetch notifications for
      * @param {NotificationType} [type] Notification type to fetch.
+     * @param {boolean} [priorityMode] When true, only returns notifications from power badge users and users that the viewer follows.
      * @param {string} [cursor] Pagination cursor.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof NotificationsApi
      */
-    public notifications(apiKey: string, fid: number, type?: NotificationType, cursor?: string, options?: AxiosRequestConfig) {
-        return NotificationsApiFp(this.configuration).notifications(apiKey, fid, type, cursor, options).then((request) => request(this.axios, this.basePath));
+    public notifications(apiKey: string, fid: number, type?: NotificationType, priorityMode?: boolean, cursor?: string, options?: AxiosRequestConfig) {
+        return NotificationsApiFp(this.configuration).notifications(apiKey, fid, type, priorityMode, cursor, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -414,13 +436,14 @@ export class NotificationsApi extends BaseAPI {
      * @param {string} apiKey API key required for authentication.
      * @param {number} fid FID of the user you you want to fetch notifications for
      * @param {string} channelIds Comma separated channel_ids (find list of all channels here - https://docs.neynar.com/reference/list-all-channels)
+     * @param {boolean} [priorityMode] When true, only returns notifications from power badge users and users that the viewer follows.
      * @param {string} [cursor] Pagination cursor.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof NotificationsApi
      */
-    public notificationsChannel(apiKey: string, fid: number, channelIds: string, cursor?: string, options?: AxiosRequestConfig) {
-        return NotificationsApiFp(this.configuration).notificationsChannel(apiKey, fid, channelIds, cursor, options).then((request) => request(this.axios, this.basePath));
+    public notificationsChannel(apiKey: string, fid: number, channelIds: string, priorityMode?: boolean, cursor?: string, options?: AxiosRequestConfig) {
+        return NotificationsApiFp(this.configuration).notificationsChannel(apiKey, fid, channelIds, priorityMode, cursor, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -429,12 +452,13 @@ export class NotificationsApi extends BaseAPI {
      * @param {string} apiKey API key required for authentication.
      * @param {number} fid FID of the user you you want to fetch notifications for
      * @param {string} parentUrls Comma separated parent_urls
+     * @param {boolean} [priorityMode] When true, only returns notifications from power badge users and users that the viewer follows.
      * @param {string} [cursor] Pagination cursor.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof NotificationsApi
      */
-    public notificationsParentUrl(apiKey: string, fid: number, parentUrls: string, cursor?: string, options?: AxiosRequestConfig) {
-        return NotificationsApiFp(this.configuration).notificationsParentUrl(apiKey, fid, parentUrls, cursor, options).then((request) => request(this.axios, this.basePath));
+    public notificationsParentUrl(apiKey: string, fid: number, parentUrls: string, priorityMode?: boolean, cursor?: string, options?: AxiosRequestConfig) {
+        return NotificationsApiFp(this.configuration).notificationsParentUrl(apiKey, fid, parentUrls, priorityMode, cursor, options).then((request) => request(this.axios, this.basePath));
     }
 }


### PR DESCRIPTION
## Overview

Adds a `priorityMode` option for notifications. This returns only notifications from users that the given user follows and users that have a power badge. 

## Example

With `priorityMode: false`
```
# index.js
const result = await client.fetchAllNotifications(489795, {priorityMode: false});
console.log(JSON.stringify(result));
```
```
$ node index.js node index.js | jq '.notifications[] | {
  "type": .type,
  "username": .cast.author.username,
  "power_badge": .cast.author.power_badge,
  "following": .cast.author.viewer_context.following
}'

{
  "type": "reply",
  "username": "pobstudio",
  "power_badge": false,
  "following": true
}
{
  "type": "reply",
  "username": "g4mer15",
  "power_badge": false,
  "following": false
}
{
  "type": "reply",
  "username": "g4mer15",
  "power_badge": false,
  "following": false
}
```


With `priorityMode: true`
```
# index.js
const result = await client.fetchAllNotifications(489795, {priorityMode: true});
console.log(JSON.stringify(result));
```
```
$ node index.js node index.js | jq '.notifications[] | {
  "type": .type,
  "username": .cast.author.username,
  "power_badge": .cast.author.power_badge,
  "following": .cast.author.viewer_context.following
}'

{
  "type": "reply",
  "username": "pobstudio",
  "power_badge": false,
  "following": true
}
{
  "type": "mention",
  "username": "icetoad.eth",
  "power_badge": true,
  "following": true
}
{
  "type": "reply",
  "username": "emilee",
  "power_badge": false,
  "following": true
}
```