### PR TITLE
feat: priority mode for search, viewer_fid in channel follower API

### DIFF
--- a/src/neynar-api/v2/openapi-farcaster/apis/cast-api.ts
+++ b/src/neynar-api/v2/openapi-farcaster/apis/cast-api.ts
@@ -115,7 +115,7 @@ export const CastApiAxiosParamCreator = function (configuration?: Configuration)
          * @param {CastParamType} type 
          * @param {number} [replyDepth] The depth of replies in the conversation that will be returned (default 2)
          * @param {boolean} [includeChronologicalParentCasts] Include all parent casts in chronological order
-         * @param {number} [viewerFid] 
+         * @param {number} [viewerFid] Providing this will return a conversation that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {number} [limit] Number of results to retrieve (default 20, max 50)
          * @param {string} [cursor] Pagination cursor.
          * @param {*} [options] Override http request option.
@@ -189,15 +189,16 @@ export const CastApiAxiosParamCreator = function (configuration?: Configuration)
          * @param {string} apiKey API key required for authentication.
          * @param {string} q Query string to search for casts
          * @param {number} [authorFid] Fid of the user whose casts you want to search
-         * @param {number} [viewerFid] Fid of the viewer of the casts, used to show viewer_context
+         * @param {number} [viewerFid] Providing this will return search results that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {string} [parentUrl] Parent URL of the casts you want to search
          * @param {string} [channelId] Channel ID of the casts you want to search
+         * @param {boolean} [priorityMode] When true, only returns search results from power badge users and users that the viewer follows (if viewer_fid is provided).
          * @param {number} [limit] 
          * @param {string} [cursor] Pagination cursor
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        castSearch: async (apiKey: string, q: string, authorFid?: number, viewerFid?: number, parentUrl?: string, channelId?: string, limit?: number, cursor?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        castSearch: async (apiKey: string, q: string, authorFid?: number, viewerFid?: number, parentUrl?: string, channelId?: string, priorityMode?: boolean, limit?: number, cursor?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'apiKey' is not null or undefined
             assertParamExists('castSearch', 'apiKey', apiKey)
             // verify required parameter 'q' is not null or undefined
@@ -232,6 +233,10 @@ export const CastApiAxiosParamCreator = function (configuration?: Configuration)
 
             if (channelId !== undefined) {
                 localVarQueryParameter['channel_id'] = channelId;
+            }
+
+            if (priorityMode !== undefined) {
+                localVarQueryParameter['priority_mode'] = priorityMode;
             }
 
             if (limit !== undefined) {
@@ -483,7 +488,7 @@ export const CastApiFp = function(configuration?: Configuration) {
          * @param {CastParamType} type 
          * @param {number} [replyDepth] The depth of replies in the conversation that will be returned (default 2)
          * @param {boolean} [includeChronologicalParentCasts] Include all parent casts in chronological order
-         * @param {number} [viewerFid] 
+         * @param {number} [viewerFid] Providing this will return a conversation that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {number} [limit] Number of results to retrieve (default 20, max 50)
          * @param {string} [cursor] Pagination cursor.
          * @param {*} [options] Override http request option.
@@ -499,16 +504,17 @@ export const CastApiFp = function(configuration?: Configuration) {
          * @param {string} apiKey API key required for authentication.
          * @param {string} q Query string to search for casts
          * @param {number} [authorFid] Fid of the user whose casts you want to search
-         * @param {number} [viewerFid] Fid of the viewer of the casts, used to show viewer_context
+         * @param {number} [viewerFid] Providing this will return search results that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {string} [parentUrl] Parent URL of the casts you want to search
          * @param {string} [channelId] Channel ID of the casts you want to search
+         * @param {boolean} [priorityMode] When true, only returns search results from power badge users and users that the viewer follows (if viewer_fid is provided).
          * @param {number} [limit] 
          * @param {string} [cursor] Pagination cursor
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async castSearch(apiKey: string, q: string, authorFid?: number, viewerFid?: number, parentUrl?: string, channelId?: string, limit?: number, cursor?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<CastsSearchResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.castSearch(apiKey, q, authorFid, viewerFid, parentUrl, channelId, limit, cursor, options);
+        async castSearch(apiKey: string, q: string, authorFid?: number, viewerFid?: number, parentUrl?: string, channelId?: string, priorityMode?: boolean, limit?: number, cursor?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<CastsSearchResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.castSearch(apiKey, q, authorFid, viewerFid, parentUrl, channelId, priorityMode, limit, cursor, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -594,7 +600,7 @@ export const CastApiFactory = function (configuration?: Configuration, basePath?
          * @param {CastParamType} type 
          * @param {number} [replyDepth] The depth of replies in the conversation that will be returned (default 2)
          * @param {boolean} [includeChronologicalParentCasts] Include all parent casts in chronological order
-         * @param {number} [viewerFid] 
+         * @param {number} [viewerFid] Providing this will return a conversation that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {number} [limit] Number of results to retrieve (default 20, max 50)
          * @param {string} [cursor] Pagination cursor.
          * @param {*} [options] Override http request option.
@@ -609,16 +615,17 @@ export const CastApiFactory = function (configuration?: Configuration, basePath?
          * @param {string} apiKey API key required for authentication.
          * @param {string} q Query string to search for casts
          * @param {number} [authorFid] Fid of the user whose casts you want to search
-         * @param {number} [viewerFid] Fid of the viewer of the casts, used to show viewer_context
+         * @param {number} [viewerFid] Providing this will return search results that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {string} [parentUrl] Parent URL of the casts you want to search
          * @param {string} [channelId] Channel ID of the casts you want to search
+         * @param {boolean} [priorityMode] When true, only returns search results from power badge users and users that the viewer follows (if viewer_fid is provided).
          * @param {number} [limit] 
          * @param {string} [cursor] Pagination cursor
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        castSearch(apiKey: string, q: string, authorFid?: number, viewerFid?: number, parentUrl?: string, channelId?: string, limit?: number, cursor?: string, options?: any): AxiosPromise<CastsSearchResponse> {
-            return localVarFp.castSearch(apiKey, q, authorFid, viewerFid, parentUrl, channelId, limit, cursor, options).then((request) => request(axios, basePath));
+        castSearch(apiKey: string, q: string, authorFid?: number, viewerFid?: number, parentUrl?: string, channelId?: string, priorityMode?: boolean, limit?: number, cursor?: string, options?: any): AxiosPromise<CastsSearchResponse> {
+            return localVarFp.castSearch(apiKey, q, authorFid, viewerFid, parentUrl, channelId, priorityMode, limit, cursor, options).then((request) => request(axios, basePath));
         },
         /**
          * Retrieve multiple casts using their respective hashes.
@@ -701,7 +708,7 @@ export class CastApi extends BaseAPI {
      * @param {CastParamType} type 
      * @param {number} [replyDepth] The depth of replies in the conversation that will be returned (default 2)
      * @param {boolean} [includeChronologicalParentCasts] Include all parent casts in chronological order
-     * @param {number} [viewerFid] 
+     * @param {number} [viewerFid] Providing this will return a conversation that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
      * @param {number} [limit] Number of results to retrieve (default 20, max 50)
      * @param {string} [cursor] Pagination cursor.
      * @param {*} [options] Override http request option.
@@ -718,17 +725,18 @@ export class CastApi extends BaseAPI {
      * @param {string} apiKey API key required for authentication.
      * @param {string} q Query string to search for casts
      * @param {number} [authorFid] Fid of the user whose casts you want to search
-     * @param {number} [viewerFid] Fid of the viewer of the casts, used to show viewer_context
+     * @param {number} [viewerFid] Providing this will return search results that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
      * @param {string} [parentUrl] Parent URL of the casts you want to search
      * @param {string} [channelId] Channel ID of the casts you want to search
+     * @param {boolean} [priorityMode] When true, only returns search results from power badge users and users that the viewer follows (if viewer_fid is provided).
      * @param {number} [limit] 
      * @param {string} [cursor] Pagination cursor
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof CastApi
      */
-    public castSearch(apiKey: string, q: string, authorFid?: number, viewerFid?: number, parentUrl?: string, channelId?: string, limit?: number, cursor?: string, options?: AxiosRequestConfig) {
-        return CastApiFp(this.configuration).castSearch(apiKey, q, authorFid, viewerFid, parentUrl, channelId, limit, cursor, options).then((request) => request(this.axios, this.basePath));
+    public castSearch(apiKey: string, q: string, authorFid?: number, viewerFid?: number, parentUrl?: string, channelId?: string, priorityMode?: boolean, limit?: number, cursor?: string, options?: AxiosRequestConfig) {
+        return CastApiFp(this.configuration).castSearch(apiKey, q, authorFid, viewerFid, parentUrl, channelId, priorityMode, limit, cursor, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/src/neynar-api/v2/openapi-farcaster/apis/channel-api.ts
+++ b/src/neynar-api/v2/openapi-farcaster/apis/channel-api.ts
@@ -222,12 +222,13 @@ export const ChannelApiAxiosParamCreator = function (configuration?: Configurati
          * @summary Retrieve followers for a given channel
          * @param {string} apiKey API key required for authentication.
          * @param {string} id Channel ID for the channel being queried
+         * @param {number} [viewerFid] Providing this will return a list of followers that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {string} [cursor] Pagination cursor.
          * @param {number} [limit] Number of followers to retrieve (default 25, max 1000)
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        channelFollowers: async (apiKey: string, id: string, cursor?: string, limit?: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        channelFollowers: async (apiKey: string, id: string, viewerFid?: number, cursor?: string, limit?: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'apiKey' is not null or undefined
             assertParamExists('channelFollowers', 'apiKey', apiKey)
             // verify required parameter 'id' is not null or undefined
@@ -246,6 +247,10 @@ export const ChannelApiAxiosParamCreator = function (configuration?: Configurati
 
             if (id !== undefined) {
                 localVarQueryParameter['id'] = id;
+            }
+
+            if (viewerFid !== undefined) {
+                localVarQueryParameter['viewer_fid'] = viewerFid;
             }
 
             if (cursor !== undefined) {
@@ -485,7 +490,7 @@ export const ChannelApiAxiosParamCreator = function (configuration?: Configurati
          * @summary Retrieve relevant channel followers for a given user
          * @param {string} apiKey API key required for authentication.
          * @param {string} id Channel id being queried
-         * @param {number} viewerFid Viewer who\&#39;s looking at the channel
+         * @param {number} viewerFid The FID of the user to customize this response for. Providing this will also return a list of followers that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -877,13 +882,14 @@ export const ChannelApiFp = function(configuration?: Configuration) {
          * @summary Retrieve followers for a given channel
          * @param {string} apiKey API key required for authentication.
          * @param {string} id Channel ID for the channel being queried
+         * @param {number} [viewerFid] Providing this will return a list of followers that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {string} [cursor] Pagination cursor.
          * @param {number} [limit] Number of followers to retrieve (default 25, max 1000)
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async channelFollowers(apiKey: string, id: string, cursor?: string, limit?: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<UsersResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.channelFollowers(apiKey, id, cursor, limit, options);
+        async channelFollowers(apiKey: string, id: string, viewerFid?: number, cursor?: string, limit?: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<UsersResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.channelFollowers(apiKey, id, viewerFid, cursor, limit, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -946,7 +952,7 @@ export const ChannelApiFp = function(configuration?: Configuration) {
          * @summary Retrieve relevant channel followers for a given user
          * @param {string} apiKey API key required for authentication.
          * @param {string} id Channel id being queried
-         * @param {number} viewerFid Viewer who\&#39;s looking at the channel
+         * @param {number} viewerFid The FID of the user to customize this response for. Providing this will also return a list of followers that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -1086,13 +1092,14 @@ export const ChannelApiFactory = function (configuration?: Configuration, basePa
          * @summary Retrieve followers for a given channel
          * @param {string} apiKey API key required for authentication.
          * @param {string} id Channel ID for the channel being queried
+         * @param {number} [viewerFid] Providing this will return a list of followers that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {string} [cursor] Pagination cursor.
          * @param {number} [limit] Number of followers to retrieve (default 25, max 1000)
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        channelFollowers(apiKey: string, id: string, cursor?: string, limit?: number, options?: any): AxiosPromise<UsersResponse> {
-            return localVarFp.channelFollowers(apiKey, id, cursor, limit, options).then((request) => request(axios, basePath));
+        channelFollowers(apiKey: string, id: string, viewerFid?: number, cursor?: string, limit?: number, options?: any): AxiosPromise<UsersResponse> {
+            return localVarFp.channelFollowers(apiKey, id, viewerFid, cursor, limit, options).then((request) => request(axios, basePath));
         },
         /**
          * Returns a list of users who are active in a given channel, ordered by ascending FIDs
@@ -1150,7 +1157,7 @@ export const ChannelApiFactory = function (configuration?: Configuration, basePa
          * @summary Retrieve relevant channel followers for a given user
          * @param {string} apiKey API key required for authentication.
          * @param {string} id Channel id being queried
-         * @param {number} viewerFid Viewer who\&#39;s looking at the channel
+         * @param {number} viewerFid The FID of the user to customize this response for. Providing this will also return a list of followers that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -1289,14 +1296,15 @@ export class ChannelApi extends BaseAPI {
      * @summary Retrieve followers for a given channel
      * @param {string} apiKey API key required for authentication.
      * @param {string} id Channel ID for the channel being queried
+     * @param {number} [viewerFid] Providing this will return a list of followers that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
      * @param {string} [cursor] Pagination cursor.
      * @param {number} [limit] Number of followers to retrieve (default 25, max 1000)
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof ChannelApi
      */
-    public channelFollowers(apiKey: string, id: string, cursor?: string, limit?: number, options?: AxiosRequestConfig) {
-        return ChannelApiFp(this.configuration).channelFollowers(apiKey, id, cursor, limit, options).then((request) => request(this.axios, this.basePath));
+    public channelFollowers(apiKey: string, id: string, viewerFid?: number, cursor?: string, limit?: number, options?: AxiosRequestConfig) {
+        return ChannelApiFp(this.configuration).channelFollowers(apiKey, id, viewerFid, cursor, limit, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -1363,7 +1371,7 @@ export class ChannelApi extends BaseAPI {
      * @summary Retrieve relevant channel followers for a given user
      * @param {string} apiKey API key required for authentication.
      * @param {string} id Channel id being queried
-     * @param {number} viewerFid Viewer who\&#39;s looking at the channel
+     * @param {number} viewerFid The FID of the user to customize this response for. Providing this will also return a list of followers that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof ChannelApi

--- a/src/neynar-api/v2/openapi-farcaster/apis/feed-api.ts
+++ b/src/neynar-api/v2/openapi-farcaster/apis/feed-api.ts
@@ -60,7 +60,7 @@ export const FeedApiAxiosParamCreator = function (configuration?: Configuration)
          * @param {boolean} [withRecasts] Include recasts in the response, true by default
          * @param {number} [limit] Number of results to retrieve (default 25, max 100)
          * @param {string} [cursor] Pagination cursor.
-         * @param {number} [viewerFid] 
+         * @param {number} [viewerFid] Providing this will return a feed that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -150,7 +150,7 @@ export const FeedApiAxiosParamCreator = function (configuration?: Configuration)
          * @param {string} apiKey API key required for authentication.
          * @param {string} channelIds Comma separated list of channel ids e.g. neynar,farcaster
          * @param {boolean} [withRecasts] Include recasts in the response, true by default
-         * @param {number} [viewerFid] 
+         * @param {number} [viewerFid] Providing this will return a feed that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {boolean} [withReplies] Include replies in the response, false by default
          * @param {number} [limit] Number of results to retrieve (default 25, max 100)
          * @param {string} [cursor] Pagination cursor.
@@ -223,7 +223,7 @@ export const FeedApiAxiosParamCreator = function (configuration?: Configuration)
          * @summary Retrieve feed based on who a user is following
          * @param {string} apiKey API key required for authentication.
          * @param {number} fid fid of user whose feed you want to create
-         * @param {number} [viewerFid] 
+         * @param {number} [viewerFid] Providing this will return a feed that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {boolean} [withRecasts] Include recasts in the response, true by default
          * @param {number} [limit] Number of results to retrieve (default 25, max 100)
          * @param {string} [cursor] Pagination cursor.
@@ -287,7 +287,7 @@ export const FeedApiAxiosParamCreator = function (configuration?: Configuration)
          * @summary Retrieve a personalized For You feed for a user
          * @param {string} apiKey API key required for authentication.
          * @param {number} fid fid of user whose feed you want to create
-         * @param {number} [viewerFid] 
+         * @param {number} [viewerFid] Providing this will return a feed that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {ForYouProvider} [provider] 
          * @param {number} [limit] Number of results to retrieve (default 25, max 50)
          * @param {string} [cursor] Pagination cursor.
@@ -356,7 +356,7 @@ export const FeedApiAxiosParamCreator = function (configuration?: Configuration)
          * @summary Retrieve feed of casts with Frames, reverse chronological order
          * @param {string} apiKey API key required for authentication.
          * @param {number} [limit] Number of results to retrieve (default 25, max 100)
-         * @param {number} [viewerFid] 
+         * @param {number} [viewerFid] Providing this will return a feed that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {string} [cursor] Pagination cursor.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -409,7 +409,7 @@ export const FeedApiAxiosParamCreator = function (configuration?: Configuration)
          * @param {string} apiKey API key required for authentication.
          * @param {string} parentUrls Comma separated list of parent_urls
          * @param {boolean} [withRecasts] Include recasts in the response, true by default
-         * @param {number} [viewerFid] 
+         * @param {number} [viewerFid] Providing this will return a feed that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {boolean} [withReplies] Include replies in the response, false by default
          * @param {number} [limit] Number of results to retrieve (default 25, max 100)
          * @param {string} [cursor] Pagination cursor.
@@ -478,7 +478,7 @@ export const FeedApiAxiosParamCreator = function (configuration?: Configuration)
          * @param {string} apiKey API key required for authentication.
          * @param {number} [limit] Number of results to retrieve (max 10)
          * @param {string} [cursor] Pagination cursor
-         * @param {number} [viewerFid] 
+         * @param {number} [viewerFid] Providing this will return a feed that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {'1h' | '6h' | '12h' | '24h' | '7d'} [timeWindow] Time window for trending casts (7d window for channel feeds only)
          * @param {string} [channelId] Channel ID to filter trending casts. Less active channels might have no casts in the time window selected.
          * @param {FeedTrendingProvider} [provider] The provider of the trending casts feed.
@@ -675,7 +675,7 @@ export const FeedApiAxiosParamCreator = function (configuration?: Configuration)
          * @param {'replies' | 'recasts' | 'all'} [filter] filter to fetch only replies or recasts
          * @param {number} [limit] Number of results to retrieve (default 25, max 100)
          * @param {string} [cursor] Pagination cursor.
-         * @param {number} [viewerFid] 
+         * @param {number} [viewerFid] Providing this will return a feed that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -756,7 +756,7 @@ export const FeedApiFp = function(configuration?: Configuration) {
          * @param {boolean} [withRecasts] Include recasts in the response, true by default
          * @param {number} [limit] Number of results to retrieve (default 25, max 100)
          * @param {string} [cursor] Pagination cursor.
-         * @param {number} [viewerFid] 
+         * @param {number} [viewerFid] Providing this will return a feed that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -770,7 +770,7 @@ export const FeedApiFp = function(configuration?: Configuration) {
          * @param {string} apiKey API key required for authentication.
          * @param {string} channelIds Comma separated list of channel ids e.g. neynar,farcaster
          * @param {boolean} [withRecasts] Include recasts in the response, true by default
-         * @param {number} [viewerFid] 
+         * @param {number} [viewerFid] Providing this will return a feed that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {boolean} [withReplies] Include replies in the response, false by default
          * @param {number} [limit] Number of results to retrieve (default 25, max 100)
          * @param {string} [cursor] Pagination cursor.
@@ -787,7 +787,7 @@ export const FeedApiFp = function(configuration?: Configuration) {
          * @summary Retrieve feed based on who a user is following
          * @param {string} apiKey API key required for authentication.
          * @param {number} fid fid of user whose feed you want to create
-         * @param {number} [viewerFid] 
+         * @param {number} [viewerFid] Providing this will return a feed that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {boolean} [withRecasts] Include recasts in the response, true by default
          * @param {number} [limit] Number of results to retrieve (default 25, max 100)
          * @param {string} [cursor] Pagination cursor.
@@ -803,7 +803,7 @@ export const FeedApiFp = function(configuration?: Configuration) {
          * @summary Retrieve a personalized For You feed for a user
          * @param {string} apiKey API key required for authentication.
          * @param {number} fid fid of user whose feed you want to create
-         * @param {number} [viewerFid] 
+         * @param {number} [viewerFid] Providing this will return a feed that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {ForYouProvider} [provider] 
          * @param {number} [limit] Number of results to retrieve (default 25, max 50)
          * @param {string} [cursor] Pagination cursor.
@@ -820,7 +820,7 @@ export const FeedApiFp = function(configuration?: Configuration) {
          * @summary Retrieve feed of casts with Frames, reverse chronological order
          * @param {string} apiKey API key required for authentication.
          * @param {number} [limit] Number of results to retrieve (default 25, max 100)
-         * @param {number} [viewerFid] 
+         * @param {number} [viewerFid] Providing this will return a feed that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {string} [cursor] Pagination cursor.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -835,7 +835,7 @@ export const FeedApiFp = function(configuration?: Configuration) {
          * @param {string} apiKey API key required for authentication.
          * @param {string} parentUrls Comma separated list of parent_urls
          * @param {boolean} [withRecasts] Include recasts in the response, true by default
-         * @param {number} [viewerFid] 
+         * @param {number} [viewerFid] Providing this will return a feed that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {boolean} [withReplies] Include replies in the response, false by default
          * @param {number} [limit] Number of results to retrieve (default 25, max 100)
          * @param {string} [cursor] Pagination cursor.
@@ -852,7 +852,7 @@ export const FeedApiFp = function(configuration?: Configuration) {
          * @param {string} apiKey API key required for authentication.
          * @param {number} [limit] Number of results to retrieve (max 10)
          * @param {string} [cursor] Pagination cursor
-         * @param {number} [viewerFid] 
+         * @param {number} [viewerFid] Providing this will return a feed that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {'1h' | '6h' | '12h' | '24h' | '7d'} [timeWindow] Time window for trending casts (7d window for channel feeds only)
          * @param {string} [channelId] Channel ID to filter trending casts. Less active channels might have no casts in the time window selected.
          * @param {FeedTrendingProvider} [provider] The provider of the trending casts feed.
@@ -903,7 +903,7 @@ export const FeedApiFp = function(configuration?: Configuration) {
          * @param {'replies' | 'recasts' | 'all'} [filter] filter to fetch only replies or recasts
          * @param {number} [limit] Number of results to retrieve (default 25, max 100)
          * @param {string} [cursor] Pagination cursor.
-         * @param {number} [viewerFid] 
+         * @param {number} [viewerFid] Providing this will return a feed that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -936,7 +936,7 @@ export const FeedApiFactory = function (configuration?: Configuration, basePath?
          * @param {boolean} [withRecasts] Include recasts in the response, true by default
          * @param {number} [limit] Number of results to retrieve (default 25, max 100)
          * @param {string} [cursor] Pagination cursor.
-         * @param {number} [viewerFid] 
+         * @param {number} [viewerFid] Providing this will return a feed that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -949,7 +949,7 @@ export const FeedApiFactory = function (configuration?: Configuration, basePath?
          * @param {string} apiKey API key required for authentication.
          * @param {string} channelIds Comma separated list of channel ids e.g. neynar,farcaster
          * @param {boolean} [withRecasts] Include recasts in the response, true by default
-         * @param {number} [viewerFid] 
+         * @param {number} [viewerFid] Providing this will return a feed that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {boolean} [withReplies] Include replies in the response, false by default
          * @param {number} [limit] Number of results to retrieve (default 25, max 100)
          * @param {string} [cursor] Pagination cursor.
@@ -965,7 +965,7 @@ export const FeedApiFactory = function (configuration?: Configuration, basePath?
          * @summary Retrieve feed based on who a user is following
          * @param {string} apiKey API key required for authentication.
          * @param {number} fid fid of user whose feed you want to create
-         * @param {number} [viewerFid] 
+         * @param {number} [viewerFid] Providing this will return a feed that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {boolean} [withRecasts] Include recasts in the response, true by default
          * @param {number} [limit] Number of results to retrieve (default 25, max 100)
          * @param {string} [cursor] Pagination cursor.
@@ -980,7 +980,7 @@ export const FeedApiFactory = function (configuration?: Configuration, basePath?
          * @summary Retrieve a personalized For You feed for a user
          * @param {string} apiKey API key required for authentication.
          * @param {number} fid fid of user whose feed you want to create
-         * @param {number} [viewerFid] 
+         * @param {number} [viewerFid] Providing this will return a feed that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {ForYouProvider} [provider] 
          * @param {number} [limit] Number of results to retrieve (default 25, max 50)
          * @param {string} [cursor] Pagination cursor.
@@ -996,7 +996,7 @@ export const FeedApiFactory = function (configuration?: Configuration, basePath?
          * @summary Retrieve feed of casts with Frames, reverse chronological order
          * @param {string} apiKey API key required for authentication.
          * @param {number} [limit] Number of results to retrieve (default 25, max 100)
-         * @param {number} [viewerFid] 
+         * @param {number} [viewerFid] Providing this will return a feed that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {string} [cursor] Pagination cursor.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -1010,7 +1010,7 @@ export const FeedApiFactory = function (configuration?: Configuration, basePath?
          * @param {string} apiKey API key required for authentication.
          * @param {string} parentUrls Comma separated list of parent_urls
          * @param {boolean} [withRecasts] Include recasts in the response, true by default
-         * @param {number} [viewerFid] 
+         * @param {number} [viewerFid] Providing this will return a feed that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {boolean} [withReplies] Include replies in the response, false by default
          * @param {number} [limit] Number of results to retrieve (default 25, max 100)
          * @param {string} [cursor] Pagination cursor.
@@ -1026,7 +1026,7 @@ export const FeedApiFactory = function (configuration?: Configuration, basePath?
          * @param {string} apiKey API key required for authentication.
          * @param {number} [limit] Number of results to retrieve (max 10)
          * @param {string} [cursor] Pagination cursor
-         * @param {number} [viewerFid] 
+         * @param {number} [viewerFid] Providing this will return a feed that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {'1h' | '6h' | '12h' | '24h' | '7d'} [timeWindow] Time window for trending casts (7d window for channel feeds only)
          * @param {string} [channelId] Channel ID to filter trending casts. Less active channels might have no casts in the time window selected.
          * @param {FeedTrendingProvider} [provider] The provider of the trending casts feed.
@@ -1074,7 +1074,7 @@ export const FeedApiFactory = function (configuration?: Configuration, basePath?
          * @param {'replies' | 'recasts' | 'all'} [filter] filter to fetch only replies or recasts
          * @param {number} [limit] Number of results to retrieve (default 25, max 100)
          * @param {string} [cursor] Pagination cursor.
-         * @param {number} [viewerFid] 
+         * @param {number} [viewerFid] Providing this will return a feed that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -1106,7 +1106,7 @@ export class FeedApi extends BaseAPI {
      * @param {boolean} [withRecasts] Include recasts in the response, true by default
      * @param {number} [limit] Number of results to retrieve (default 25, max 100)
      * @param {string} [cursor] Pagination cursor.
-     * @param {number} [viewerFid] 
+     * @param {number} [viewerFid] Providing this will return a feed that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof FeedApi
@@ -1121,7 +1121,7 @@ export class FeedApi extends BaseAPI {
      * @param {string} apiKey API key required for authentication.
      * @param {string} channelIds Comma separated list of channel ids e.g. neynar,farcaster
      * @param {boolean} [withRecasts] Include recasts in the response, true by default
-     * @param {number} [viewerFid] 
+     * @param {number} [viewerFid] Providing this will return a feed that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
      * @param {boolean} [withReplies] Include replies in the response, false by default
      * @param {number} [limit] Number of results to retrieve (default 25, max 100)
      * @param {string} [cursor] Pagination cursor.
@@ -1139,7 +1139,7 @@ export class FeedApi extends BaseAPI {
      * @summary Retrieve feed based on who a user is following
      * @param {string} apiKey API key required for authentication.
      * @param {number} fid fid of user whose feed you want to create
-     * @param {number} [viewerFid] 
+     * @param {number} [viewerFid] Providing this will return a feed that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
      * @param {boolean} [withRecasts] Include recasts in the response, true by default
      * @param {number} [limit] Number of results to retrieve (default 25, max 100)
      * @param {string} [cursor] Pagination cursor.
@@ -1156,7 +1156,7 @@ export class FeedApi extends BaseAPI {
      * @summary Retrieve a personalized For You feed for a user
      * @param {string} apiKey API key required for authentication.
      * @param {number} fid fid of user whose feed you want to create
-     * @param {number} [viewerFid] 
+     * @param {number} [viewerFid] Providing this will return a feed that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
      * @param {ForYouProvider} [provider] 
      * @param {number} [limit] Number of results to retrieve (default 25, max 50)
      * @param {string} [cursor] Pagination cursor.
@@ -1174,7 +1174,7 @@ export class FeedApi extends BaseAPI {
      * @summary Retrieve feed of casts with Frames, reverse chronological order
      * @param {string} apiKey API key required for authentication.
      * @param {number} [limit] Number of results to retrieve (default 25, max 100)
-     * @param {number} [viewerFid] 
+     * @param {number} [viewerFid] Providing this will return a feed that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
      * @param {string} [cursor] Pagination cursor.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -1190,7 +1190,7 @@ export class FeedApi extends BaseAPI {
      * @param {string} apiKey API key required for authentication.
      * @param {string} parentUrls Comma separated list of parent_urls
      * @param {boolean} [withRecasts] Include recasts in the response, true by default
-     * @param {number} [viewerFid] 
+     * @param {number} [viewerFid] Providing this will return a feed that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
      * @param {boolean} [withReplies] Include replies in the response, false by default
      * @param {number} [limit] Number of results to retrieve (default 25, max 100)
      * @param {string} [cursor] Pagination cursor.
@@ -1208,7 +1208,7 @@ export class FeedApi extends BaseAPI {
      * @param {string} apiKey API key required for authentication.
      * @param {number} [limit] Number of results to retrieve (max 10)
      * @param {string} [cursor] Pagination cursor
-     * @param {number} [viewerFid] 
+     * @param {number} [viewerFid] Providing this will return a feed that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
      * @param {'1h' | '6h' | '12h' | '24h' | '7d'} [timeWindow] Time window for trending casts (7d window for channel feeds only)
      * @param {string} [channelId] Channel ID to filter trending casts. Less active channels might have no casts in the time window selected.
      * @param {FeedTrendingProvider} [provider] The provider of the trending casts feed.
@@ -1262,7 +1262,7 @@ export class FeedApi extends BaseAPI {
      * @param {'replies' | 'recasts' | 'all'} [filter] filter to fetch only replies or recasts
      * @param {number} [limit] Number of results to retrieve (default 25, max 100)
      * @param {string} [cursor] Pagination cursor.
-     * @param {number} [viewerFid] 
+     * @param {number} [viewerFid] Providing this will return a feed that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof FeedApi

--- a/src/neynar-api/v2/openapi-farcaster/apis/follows-api.ts
+++ b/src/neynar-api/v2/openapi-farcaster/apis/follows-api.ts
@@ -40,7 +40,7 @@ export const FollowsApiAxiosParamCreator = function (configuration?: Configurati
          * @summary Retrieve followers for a given user
          * @param {string} apiKey API key required for authentication.
          * @param {number} fid User who\&#39;s profile you are looking at
-         * @param {number} [viewerFid] Viewer who\&#39;s looking at the profile.
+         * @param {number} [viewerFid] Providing this will return a list of followers that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {FollowSortType} [sortType] Sort type for retrieve followers. Default is &#x60;desc_chron&#x60;
          * @param {number} [limit] Number of results to retrieve (default 20, max 100)
          * @param {string} [cursor] Pagination cursor.
@@ -104,7 +104,7 @@ export const FollowsApiAxiosParamCreator = function (configuration?: Configurati
          * @summary Retrieve a list of users followed by a user
          * @param {string} apiKey API key required for authentication.
          * @param {number} fid FID of the user whose following you want to fetch.
-         * @param {number} [viewerFid] FID of the user viewing the user.
+         * @param {number} [viewerFid] Providing this will return a list of users that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {FollowSortType} [sortType] Optional parameter to sort the users based on different criteria.
          * @param {number} [limit] Number of results to retrieve (default 25, max 100)
          * @param {string} [cursor] Pagination cursor.
@@ -168,17 +168,15 @@ export const FollowsApiAxiosParamCreator = function (configuration?: Configurati
          * @summary Retrieve relevant followers for a given user
          * @param {string} apiKey API key required for authentication.
          * @param {number} targetFid User who\&#39;s profile you are looking at
-         * @param {number} viewerFid Viewer who\&#39;s looking at the profile
+         * @param {number} [viewerFid] The FID of the user to customize this response for. Providing this will also return a list of followers that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        relevantFollowers: async (apiKey: string, targetFid: number, viewerFid: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        relevantFollowers: async (apiKey: string, targetFid: number, viewerFid?: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'apiKey' is not null or undefined
             assertParamExists('relevantFollowers', 'apiKey', apiKey)
             // verify required parameter 'targetFid' is not null or undefined
             assertParamExists('relevantFollowers', 'targetFid', targetFid)
-            // verify required parameter 'viewerFid' is not null or undefined
-            assertParamExists('relevantFollowers', 'viewerFid', viewerFid)
             const localVarPath = `/farcaster/followers/relevant`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -229,7 +227,7 @@ export const FollowsApiFp = function(configuration?: Configuration) {
          * @summary Retrieve followers for a given user
          * @param {string} apiKey API key required for authentication.
          * @param {number} fid User who\&#39;s profile you are looking at
-         * @param {number} [viewerFid] Viewer who\&#39;s looking at the profile.
+         * @param {number} [viewerFid] Providing this will return a list of followers that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {FollowSortType} [sortType] Sort type for retrieve followers. Default is &#x60;desc_chron&#x60;
          * @param {number} [limit] Number of results to retrieve (default 20, max 100)
          * @param {string} [cursor] Pagination cursor.
@@ -245,7 +243,7 @@ export const FollowsApiFp = function(configuration?: Configuration) {
          * @summary Retrieve a list of users followed by a user
          * @param {string} apiKey API key required for authentication.
          * @param {number} fid FID of the user whose following you want to fetch.
-         * @param {number} [viewerFid] FID of the user viewing the user.
+         * @param {number} [viewerFid] Providing this will return a list of users that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {FollowSortType} [sortType] Optional parameter to sort the users based on different criteria.
          * @param {number} [limit] Number of results to retrieve (default 25, max 100)
          * @param {string} [cursor] Pagination cursor.
@@ -261,11 +259,11 @@ export const FollowsApiFp = function(configuration?: Configuration) {
          * @summary Retrieve relevant followers for a given user
          * @param {string} apiKey API key required for authentication.
          * @param {number} targetFid User who\&#39;s profile you are looking at
-         * @param {number} viewerFid Viewer who\&#39;s looking at the profile
+         * @param {number} [viewerFid] The FID of the user to customize this response for. Providing this will also return a list of followers that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async relevantFollowers(apiKey: string, targetFid: number, viewerFid: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<RelevantFollowersResponse>> {
+        async relevantFollowers(apiKey: string, targetFid: number, viewerFid?: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<RelevantFollowersResponse>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.relevantFollowers(apiKey, targetFid, viewerFid, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
@@ -284,7 +282,7 @@ export const FollowsApiFactory = function (configuration?: Configuration, basePa
          * @summary Retrieve followers for a given user
          * @param {string} apiKey API key required for authentication.
          * @param {number} fid User who\&#39;s profile you are looking at
-         * @param {number} [viewerFid] Viewer who\&#39;s looking at the profile.
+         * @param {number} [viewerFid] Providing this will return a list of followers that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {FollowSortType} [sortType] Sort type for retrieve followers. Default is &#x60;desc_chron&#x60;
          * @param {number} [limit] Number of results to retrieve (default 20, max 100)
          * @param {string} [cursor] Pagination cursor.
@@ -299,7 +297,7 @@ export const FollowsApiFactory = function (configuration?: Configuration, basePa
          * @summary Retrieve a list of users followed by a user
          * @param {string} apiKey API key required for authentication.
          * @param {number} fid FID of the user whose following you want to fetch.
-         * @param {number} [viewerFid] FID of the user viewing the user.
+         * @param {number} [viewerFid] Providing this will return a list of users that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {FollowSortType} [sortType] Optional parameter to sort the users based on different criteria.
          * @param {number} [limit] Number of results to retrieve (default 25, max 100)
          * @param {string} [cursor] Pagination cursor.
@@ -314,11 +312,11 @@ export const FollowsApiFactory = function (configuration?: Configuration, basePa
          * @summary Retrieve relevant followers for a given user
          * @param {string} apiKey API key required for authentication.
          * @param {number} targetFid User who\&#39;s profile you are looking at
-         * @param {number} viewerFid Viewer who\&#39;s looking at the profile
+         * @param {number} [viewerFid] The FID of the user to customize this response for. Providing this will also return a list of followers that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        relevantFollowers(apiKey: string, targetFid: number, viewerFid: number, options?: any): AxiosPromise<RelevantFollowersResponse> {
+        relevantFollowers(apiKey: string, targetFid: number, viewerFid?: number, options?: any): AxiosPromise<RelevantFollowersResponse> {
             return localVarFp.relevantFollowers(apiKey, targetFid, viewerFid, options).then((request) => request(axios, basePath));
         },
     };
@@ -336,7 +334,7 @@ export class FollowsApi extends BaseAPI {
      * @summary Retrieve followers for a given user
      * @param {string} apiKey API key required for authentication.
      * @param {number} fid User who\&#39;s profile you are looking at
-     * @param {number} [viewerFid] Viewer who\&#39;s looking at the profile.
+     * @param {number} [viewerFid] Providing this will return a list of followers that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
      * @param {FollowSortType} [sortType] Sort type for retrieve followers. Default is &#x60;desc_chron&#x60;
      * @param {number} [limit] Number of results to retrieve (default 20, max 100)
      * @param {string} [cursor] Pagination cursor.
@@ -353,7 +351,7 @@ export class FollowsApi extends BaseAPI {
      * @summary Retrieve a list of users followed by a user
      * @param {string} apiKey API key required for authentication.
      * @param {number} fid FID of the user whose following you want to fetch.
-     * @param {number} [viewerFid] FID of the user viewing the user.
+     * @param {number} [viewerFid] Providing this will return a list of users that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
      * @param {FollowSortType} [sortType] Optional parameter to sort the users based on different criteria.
      * @param {number} [limit] Number of results to retrieve (default 25, max 100)
      * @param {string} [cursor] Pagination cursor.
@@ -370,12 +368,12 @@ export class FollowsApi extends BaseAPI {
      * @summary Retrieve relevant followers for a given user
      * @param {string} apiKey API key required for authentication.
      * @param {number} targetFid User who\&#39;s profile you are looking at
-     * @param {number} viewerFid Viewer who\&#39;s looking at the profile
+     * @param {number} [viewerFid] The FID of the user to customize this response for. Providing this will also return a list of followers that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof FollowsApi
      */
-    public relevantFollowers(apiKey: string, targetFid: number, viewerFid: number, options?: AxiosRequestConfig) {
+    public relevantFollowers(apiKey: string, targetFid: number, viewerFid?: number, options?: AxiosRequestConfig) {
         return FollowsApiFp(this.configuration).relevantFollowers(apiKey, targetFid, viewerFid, options).then((request) => request(this.axios, this.basePath));
     }
 }

--- a/src/neynar-api/v2/openapi-farcaster/apis/notifications-api.ts
+++ b/src/neynar-api/v2/openapi-farcaster/apis/notifications-api.ts
@@ -84,9 +84,9 @@ export const NotificationsApiAxiosParamCreator = function (configuration?: Confi
          * Returns a list of notifications for a specific FID.
          * @summary Retrieve notifications for a given user
          * @param {string} apiKey API key required for authentication.
-         * @param {number} fid FID of the user you you want to fetch notifications for
+         * @param {number} fid FID of the user you you want to fetch notifications for. The response will respect this user\&#39;s mutes and blocks.
          * @param {NotificationType} [type] Notification type to fetch.
-         * @param {boolean} [priorityMode] When true, only returns notifications from power badge users and users that the viewer follows.
+         * @param {boolean} [priorityMode] When true, only returns notifications from power badge users and users that the viewer follows (if viewer_fid is provided).
          * @param {string} [cursor] Pagination cursor.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -143,9 +143,9 @@ export const NotificationsApiAxiosParamCreator = function (configuration?: Confi
          * Returns a list of notifications for a user in specific channels
          * @summary Retrieve notifications for a user in given channels
          * @param {string} apiKey API key required for authentication.
-         * @param {number} fid FID of the user you you want to fetch notifications for
+         * @param {number} fid FID of the user you you want to fetch notifications for. The response will respect this user\&#39;s mutes and blocks.
          * @param {string} channelIds Comma separated channel_ids (find list of all channels here - https://docs.neynar.com/reference/list-all-channels)
-         * @param {boolean} [priorityMode] When true, only returns notifications from power badge users and users that the viewer follows.
+         * @param {boolean} [priorityMode] When true, only returns notifications from power badge users and users that the viewer follows (if viewer_fid is provided).
          * @param {string} [cursor] Pagination cursor.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -204,9 +204,9 @@ export const NotificationsApiAxiosParamCreator = function (configuration?: Confi
          * Returns a list of notifications for a user in specific parent_urls
          * @summary Retrieve notifications for a user in given parent_urls
          * @param {string} apiKey API key required for authentication.
-         * @param {number} fid FID of the user you you want to fetch notifications for
+         * @param {number} fid FID of the user you you want to fetch notifications for. The response will respect this user\&#39;s mutes and blocks.
          * @param {string} parentUrls Comma separated parent_urls
-         * @param {boolean} [priorityMode] When true, only returns notifications from power badge users and users that the viewer follows.
+         * @param {boolean} [priorityMode] When true, only returns notifications from power badge users and users that the viewer follows (if viewer_fid is provided).
          * @param {string} [cursor] Pagination cursor.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -287,9 +287,9 @@ export const NotificationsApiFp = function(configuration?: Configuration) {
          * Returns a list of notifications for a specific FID.
          * @summary Retrieve notifications for a given user
          * @param {string} apiKey API key required for authentication.
-         * @param {number} fid FID of the user you you want to fetch notifications for
+         * @param {number} fid FID of the user you you want to fetch notifications for. The response will respect this user\&#39;s mutes and blocks.
          * @param {NotificationType} [type] Notification type to fetch.
-         * @param {boolean} [priorityMode] When true, only returns notifications from power badge users and users that the viewer follows.
+         * @param {boolean} [priorityMode] When true, only returns notifications from power badge users and users that the viewer follows (if viewer_fid is provided).
          * @param {string} [cursor] Pagination cursor.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -302,9 +302,9 @@ export const NotificationsApiFp = function(configuration?: Configuration) {
          * Returns a list of notifications for a user in specific channels
          * @summary Retrieve notifications for a user in given channels
          * @param {string} apiKey API key required for authentication.
-         * @param {number} fid FID of the user you you want to fetch notifications for
+         * @param {number} fid FID of the user you you want to fetch notifications for. The response will respect this user\&#39;s mutes and blocks.
          * @param {string} channelIds Comma separated channel_ids (find list of all channels here - https://docs.neynar.com/reference/list-all-channels)
-         * @param {boolean} [priorityMode] When true, only returns notifications from power badge users and users that the viewer follows.
+         * @param {boolean} [priorityMode] When true, only returns notifications from power badge users and users that the viewer follows (if viewer_fid is provided).
          * @param {string} [cursor] Pagination cursor.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -317,9 +317,9 @@ export const NotificationsApiFp = function(configuration?: Configuration) {
          * Returns a list of notifications for a user in specific parent_urls
          * @summary Retrieve notifications for a user in given parent_urls
          * @param {string} apiKey API key required for authentication.
-         * @param {number} fid FID of the user you you want to fetch notifications for
+         * @param {number} fid FID of the user you you want to fetch notifications for. The response will respect this user\&#39;s mutes and blocks.
          * @param {string} parentUrls Comma separated parent_urls
-         * @param {boolean} [priorityMode] When true, only returns notifications from power badge users and users that the viewer follows.
+         * @param {boolean} [priorityMode] When true, only returns notifications from power badge users and users that the viewer follows (if viewer_fid is provided).
          * @param {string} [cursor] Pagination cursor.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -353,9 +353,9 @@ export const NotificationsApiFactory = function (configuration?: Configuration, 
          * Returns a list of notifications for a specific FID.
          * @summary Retrieve notifications for a given user
          * @param {string} apiKey API key required for authentication.
-         * @param {number} fid FID of the user you you want to fetch notifications for
+         * @param {number} fid FID of the user you you want to fetch notifications for. The response will respect this user\&#39;s mutes and blocks.
          * @param {NotificationType} [type] Notification type to fetch.
-         * @param {boolean} [priorityMode] When true, only returns notifications from power badge users and users that the viewer follows.
+         * @param {boolean} [priorityMode] When true, only returns notifications from power badge users and users that the viewer follows (if viewer_fid is provided).
          * @param {string} [cursor] Pagination cursor.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -367,9 +367,9 @@ export const NotificationsApiFactory = function (configuration?: Configuration, 
          * Returns a list of notifications for a user in specific channels
          * @summary Retrieve notifications for a user in given channels
          * @param {string} apiKey API key required for authentication.
-         * @param {number} fid FID of the user you you want to fetch notifications for
+         * @param {number} fid FID of the user you you want to fetch notifications for. The response will respect this user\&#39;s mutes and blocks.
          * @param {string} channelIds Comma separated channel_ids (find list of all channels here - https://docs.neynar.com/reference/list-all-channels)
-         * @param {boolean} [priorityMode] When true, only returns notifications from power badge users and users that the viewer follows.
+         * @param {boolean} [priorityMode] When true, only returns notifications from power badge users and users that the viewer follows (if viewer_fid is provided).
          * @param {string} [cursor] Pagination cursor.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -381,9 +381,9 @@ export const NotificationsApiFactory = function (configuration?: Configuration, 
          * Returns a list of notifications for a user in specific parent_urls
          * @summary Retrieve notifications for a user in given parent_urls
          * @param {string} apiKey API key required for authentication.
-         * @param {number} fid FID of the user you you want to fetch notifications for
+         * @param {number} fid FID of the user you you want to fetch notifications for. The response will respect this user\&#39;s mutes and blocks.
          * @param {string} parentUrls Comma separated parent_urls
-         * @param {boolean} [priorityMode] When true, only returns notifications from power badge users and users that the viewer follows.
+         * @param {boolean} [priorityMode] When true, only returns notifications from power badge users and users that the viewer follows (if viewer_fid is provided).
          * @param {string} [cursor] Pagination cursor.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -418,9 +418,9 @@ export class NotificationsApi extends BaseAPI {
      * Returns a list of notifications for a specific FID.
      * @summary Retrieve notifications for a given user
      * @param {string} apiKey API key required for authentication.
-     * @param {number} fid FID of the user you you want to fetch notifications for
+     * @param {number} fid FID of the user you you want to fetch notifications for. The response will respect this user\&#39;s mutes and blocks.
      * @param {NotificationType} [type] Notification type to fetch.
-     * @param {boolean} [priorityMode] When true, only returns notifications from power badge users and users that the viewer follows.
+     * @param {boolean} [priorityMode] When true, only returns notifications from power badge users and users that the viewer follows (if viewer_fid is provided).
      * @param {string} [cursor] Pagination cursor.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -434,9 +434,9 @@ export class NotificationsApi extends BaseAPI {
      * Returns a list of notifications for a user in specific channels
      * @summary Retrieve notifications for a user in given channels
      * @param {string} apiKey API key required for authentication.
-     * @param {number} fid FID of the user you you want to fetch notifications for
+     * @param {number} fid FID of the user you you want to fetch notifications for. The response will respect this user\&#39;s mutes and blocks.
      * @param {string} channelIds Comma separated channel_ids (find list of all channels here - https://docs.neynar.com/reference/list-all-channels)
-     * @param {boolean} [priorityMode] When true, only returns notifications from power badge users and users that the viewer follows.
+     * @param {boolean} [priorityMode] When true, only returns notifications from power badge users and users that the viewer follows (if viewer_fid is provided).
      * @param {string} [cursor] Pagination cursor.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -450,9 +450,9 @@ export class NotificationsApi extends BaseAPI {
      * Returns a list of notifications for a user in specific parent_urls
      * @summary Retrieve notifications for a user in given parent_urls
      * @param {string} apiKey API key required for authentication.
-     * @param {number} fid FID of the user you you want to fetch notifications for
+     * @param {number} fid FID of the user you you want to fetch notifications for. The response will respect this user\&#39;s mutes and blocks.
      * @param {string} parentUrls Comma separated parent_urls
-     * @param {boolean} [priorityMode] When true, only returns notifications from power badge users and users that the viewer follows.
+     * @param {boolean} [priorityMode] When true, only returns notifications from power badge users and users that the viewer follows (if viewer_fid is provided).
      * @param {string} [cursor] Pagination cursor.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}

--- a/src/neynar-api/v2/openapi-farcaster/apis/reaction-api.ts
+++ b/src/neynar-api/v2/openapi-farcaster/apis/reaction-api.ts
@@ -131,7 +131,7 @@ export const ReactionApiAxiosParamCreator = function (configuration?: Configurat
          * @param {string} apiKey API key required for authentication.
          * @param {string} hash 
          * @param {string} types Customize which reaction types the request should search for. This is a comma-separated string that can include the following values: \&#39;likes\&#39; and \&#39;recasts\&#39;. By default api returns both. To select multiple types, use a comma-separated list of these values. 
-         * @param {number} [viewerFid] 
+         * @param {number} [viewerFid] Providing this will return a list of reactions that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {number} [limit] Number of results to retrieve (default 25, max 100)
          * @param {string} [cursor] Pagination cursor.
          * @param {*} [options] Override http request option.
@@ -197,7 +197,7 @@ export const ReactionApiAxiosParamCreator = function (configuration?: Configurat
          * @param {string} apiKey API key required for authentication.
          * @param {number} fid 
          * @param {ReactionsType} type Type of reaction to fetch (likes or recasts or all)
-         * @param {number} [viewerFid] 
+         * @param {number} [viewerFid] Providing this will return a list of reactions that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {number} [limit] Number of results to retrieve (default 25, max 100)
          * @param {string} [cursor] Pagination cursor.
          * @param {*} [options] Override http request option.
@@ -297,7 +297,7 @@ export const ReactionApiFp = function(configuration?: Configuration) {
          * @param {string} apiKey API key required for authentication.
          * @param {string} hash 
          * @param {string} types Customize which reaction types the request should search for. This is a comma-separated string that can include the following values: \&#39;likes\&#39; and \&#39;recasts\&#39;. By default api returns both. To select multiple types, use a comma-separated list of these values. 
-         * @param {number} [viewerFid] 
+         * @param {number} [viewerFid] Providing this will return a list of reactions that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {number} [limit] Number of results to retrieve (default 25, max 100)
          * @param {string} [cursor] Pagination cursor.
          * @param {*} [options] Override http request option.
@@ -313,7 +313,7 @@ export const ReactionApiFp = function(configuration?: Configuration) {
          * @param {string} apiKey API key required for authentication.
          * @param {number} fid 
          * @param {ReactionsType} type Type of reaction to fetch (likes or recasts or all)
-         * @param {number} [viewerFid] 
+         * @param {number} [viewerFid] Providing this will return a list of reactions that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {number} [limit] Number of results to retrieve (default 25, max 100)
          * @param {string} [cursor] Pagination cursor.
          * @param {*} [options] Override http request option.
@@ -361,7 +361,7 @@ export const ReactionApiFactory = function (configuration?: Configuration, baseP
          * @param {string} apiKey API key required for authentication.
          * @param {string} hash 
          * @param {string} types Customize which reaction types the request should search for. This is a comma-separated string that can include the following values: \&#39;likes\&#39; and \&#39;recasts\&#39;. By default api returns both. To select multiple types, use a comma-separated list of these values. 
-         * @param {number} [viewerFid] 
+         * @param {number} [viewerFid] Providing this will return a list of reactions that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {number} [limit] Number of results to retrieve (default 25, max 100)
          * @param {string} [cursor] Pagination cursor.
          * @param {*} [options] Override http request option.
@@ -376,7 +376,7 @@ export const ReactionApiFactory = function (configuration?: Configuration, baseP
          * @param {string} apiKey API key required for authentication.
          * @param {number} fid 
          * @param {ReactionsType} type Type of reaction to fetch (likes or recasts or all)
-         * @param {number} [viewerFid] 
+         * @param {number} [viewerFid] Providing this will return a list of reactions that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {number} [limit] Number of results to retrieve (default 25, max 100)
          * @param {string} [cursor] Pagination cursor.
          * @param {*} [options] Override http request option.
@@ -427,7 +427,7 @@ export class ReactionApi extends BaseAPI {
      * @param {string} apiKey API key required for authentication.
      * @param {string} hash 
      * @param {string} types Customize which reaction types the request should search for. This is a comma-separated string that can include the following values: \&#39;likes\&#39; and \&#39;recasts\&#39;. By default api returns both. To select multiple types, use a comma-separated list of these values. 
-     * @param {number} [viewerFid] 
+     * @param {number} [viewerFid] Providing this will return a list of reactions that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
      * @param {number} [limit] Number of results to retrieve (default 25, max 100)
      * @param {string} [cursor] Pagination cursor.
      * @param {*} [options] Override http request option.
@@ -444,7 +444,7 @@ export class ReactionApi extends BaseAPI {
      * @param {string} apiKey API key required for authentication.
      * @param {number} fid 
      * @param {ReactionsType} type Type of reaction to fetch (likes or recasts or all)
-     * @param {number} [viewerFid] 
+     * @param {number} [viewerFid] Providing this will return a list of reactions that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
      * @param {number} [limit] Number of results to retrieve (default 25, max 100)
      * @param {string} [cursor] Pagination cursor.
      * @param {*} [options] Override http request option.

--- a/src/neynar-api/v2/openapi-farcaster/apis/user-api.ts
+++ b/src/neynar-api/v2/openapi-farcaster/apis/user-api.ts
@@ -645,7 +645,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * @summary Search for Usernames
          * @param {string} apiKey API key required for authentication.
          * @param {string} q 
-         * @param {number} [viewerFid] 
+         * @param {number} [viewerFid] Providing this will return search results that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {number} [limit] 
          * @param {string} [cursor] Pagination cursor.
          * @param {*} [options] Override http request option.
@@ -875,7 +875,7 @@ export const UserApiFp = function(configuration?: Configuration) {
          * @summary Search for Usernames
          * @param {string} apiKey API key required for authentication.
          * @param {string} q 
-         * @param {number} [viewerFid] 
+         * @param {number} [viewerFid] Providing this will return search results that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {number} [limit] 
          * @param {string} [cursor] Pagination cursor.
          * @param {*} [options] Override http request option.
@@ -1048,7 +1048,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @summary Search for Usernames
          * @param {string} apiKey API key required for authentication.
          * @param {string} q 
-         * @param {number} [viewerFid] 
+         * @param {number} [viewerFid] Providing this will return search results that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {number} [limit] 
          * @param {string} [cursor] Pagination cursor.
          * @param {*} [options] Override http request option.
@@ -1246,7 +1246,7 @@ export class UserApi extends BaseAPI {
      * @summary Search for Usernames
      * @param {string} apiKey API key required for authentication.
      * @param {string} q 
-     * @param {number} [viewerFid] 
+     * @param {number} [viewerFid] Providing this will return search results that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
      * @param {number} [limit] 
      * @param {string} [cursor] Pagination cursor.
      * @param {*} [options] Override http request option.


### PR DESCRIPTION
## Overview

This PR has 3 small changes.

1. Adding priority mode to cast search
2. Adding viewer_fid to /channel/followers
3. Updating docstrings for viewer_fid to document blocks

## Examples

[coming soon]