### PR TITLE
feat: `members_only` flag for channel feeds

### DIFF
--- a/src/neynar-api/neynar-api-client.ts
+++ b/src/neynar-api/neynar-api-client.ts
@@ -1743,6 +1743,7 @@ export class NeynarAPIClient {
    * @param {Array<number>} [options.fids] - Used for creating a feed based on a list of FIDs. Requires 'feedType' and 'filterType'.
    * @param {string} [options.parentUrl] - Used for fetching content under a specific parent URL. Requires 'feedType' and 'filterType'.
    * @param {string} [options.channelId] Used when filter_type=channel_id can be used to fetch all casts under a channel. Requires feed_type and filter_type
+   * @param {boolean} [options.membersOnly] Used when filter_type=channel_id. Only include casts from members of the channel. True by default.
    * @param {string} [options.embedUrl] - Used when filter_type=embed_url can be used to fetch all casts with an embed url that contains embed_url. Requires feed_type and filter_type
    * @param {Array<EmbedType>} [options.embedTypes] Used when filter_type&#x3D;embed_types can be used to fetch all casts with matching content types. Requires feed_type and filter_type
    * @param {boolean} [options.withRecasts] - Whether to include recasts in the response. True by default.
@@ -1769,6 +1770,7 @@ export class NeynarAPIClient {
       fids?: number[];
       parentUrl?: string;
       channelId?: string;
+      membersOnly?: boolean;
       embedUrl?: string;
       embedTypes?: EmbedType[];
       limit?: number;
@@ -1788,10 +1790,11 @@ export class NeynarAPIClient {
    * @param {Object} [options] - Optional parameters for customizing the feed.
    * @param {boolean} [options.withRecasts] - Whether to include recasts in the response. True by default.
    * @param {boolean} [options.withReplies] - Whether to include replies in the response. False by default.
+   * @param {boolean} [options.membersOnly] Used when filter_type&#x3D;channel_id. Only include casts from members of the channel. True by default.
    * @param {number} [options.limit] - Number of results to retrieve (default 25, max 100).
    * @param {string} [options.cursor] - Pagination cursor for the next set of results. Omit this parameter for the initial request.
    * @param {number} [options.viewerFid] - Providing this will return a feed that respects this user's mutes and blocks and includes `viewer_context`.
-   * @param {boolean} [options.shouldModerate] - Whether to include only casts liked by the moderator in the response. True by default.
+   * @param {boolean} [options.shouldModerate] - Whether to include only casts liked by the moderator in the response. Deprecated.
    *
    * @returns {Promise<FeedResponse>} A promise that resolves to a `FeedResponse` object,
    *   containing the feed for the specified channel IDs.
@@ -1809,6 +1812,7 @@ export class NeynarAPIClient {
     options?: {
       withRecasts?: boolean;
       withReplies?: boolean;
+      membersOnly?: boolean;
       limit?: number;
       cursor?: string;
       viewerFid?: number;

--- a/src/neynar-api/v2/client.ts
+++ b/src/neynar-api/v2/client.ts
@@ -1349,6 +1349,7 @@ export class NeynarV2APIClient {
    * @param {Array<number>} [options.fids] - Used for creating a feed based on a list of FIDs. Requires 'feedType' and 'filterType'.
    * @param {string} [options.parentUrl] - Used for fetching content under a specific parent URL. Requires 'feedType' and 'filterType'.
    * @param {string} [options.channelId] Used when filter_type=channel_id can be used to fetch all casts under a channel. Requires feed_type and filter_type
+   * @param {boolean} [membersOnly] Used when filter_type=channel_id. Only include casts from members of the channel. True by default.
    * @param {string} [options.embedUrl] - Used when filter_type=embed_url can be used to fetch all casts with an embed url that contains embed_url. Requires feed_type and filter_type
    * @param {Array<EmbedType>} [options.embedTypes] Used when filter_type&#x3D;embed_types can be used to fetch all casts with matching content types. Requires feed_type and filter_type
    * @param {boolean} [options.withRecasts] - Whether to include recasts in the response. True by default.
@@ -1375,6 +1376,7 @@ export class NeynarV2APIClient {
       fids?: number[];
       parentUrl?: string;
       channelId?: string;
+      membersOnly?: boolean;
       embedUrl?: string;
       embedTypes?: EmbedType[];
       limit?: number;
@@ -1393,6 +1395,7 @@ export class NeynarV2APIClient {
       _fids,
       options?.parentUrl,
       options?.channelId,
+      options?.membersOnly,
       options?.embedUrl,
       options?.embedTypes,
       options?.withRecasts,
@@ -1411,10 +1414,11 @@ export class NeynarV2APIClient {
    * @param {Object} [options] - Optional parameters for customizing the feed.
    * @param {boolean} [options.withRecasts] - Whether to include recasts in the response. True by default.
    * @param {boolean} [options.withReplies] - Whether to include replies in the response. False by default.
+   * @param {boolean} [options.membersOnly] Used when filter_type&#x3D;channel_id. Only include casts from members of the channel. True by default.
    * @param {number} [options.limit] - Number of results to retrieve (default 25, max 100).
    * @param {string} [options.cursor] - Pagination cursor for the next set of results. Omit this parameter for the initial request.
    * @param {number} [options.viewerFid] - Providing this will return a feed that respects this user's mutes and blocks and includes `viewer_context`.
-   * @param {boolean} [options.shouldModerate] - Whether to include only casts liked by the moderator in the response. True by default.
+   * @param {boolean} [options.shouldModerate] - Whether to include only casts liked by the moderator in the response. Deprecated.
    *
    * @returns {Promise<FeedResponse>} A promise that resolves to a `FeedResponse` object,
    *   containing the feed for the specified channel IDs.
@@ -1432,6 +1436,7 @@ export class NeynarV2APIClient {
     options?: {
       withRecasts?: boolean;
       withReplies?: boolean;
+      membersOnly?: boolean;
       limit?: number;
       cursor?: string;
       viewerFid?: number;
@@ -1445,6 +1450,7 @@ export class NeynarV2APIClient {
       options?.withRecasts,
       options?.viewerFid,
       options?.withReplies,
+      options?.membersOnly,
       options?.limit,
       options?.cursor,
       options?.shouldModerate

--- a/src/neynar-api/v2/openapi-farcaster/apis/feed-api.ts
+++ b/src/neynar-api/v2/openapi-farcaster/apis/feed-api.ts
@@ -54,7 +54,8 @@ export const FeedApiAxiosParamCreator = function (configuration?: Configuration)
          * @param {number} [fid] (Optional) fid of user whose feed you want to create. By default, the API expects this field, except if you pass a filter_type
          * @param {string} [fids] Used when filter_type&#x3D;fids . Create a feed based on a list of fids. Max array size is 250. Requires feed_type and filter_type.
          * @param {string} [parentUrl] Used when filter_type&#x3D;parent_url can be used to fetch content under any parent url e.g. FIP-2 channels on Warpcast. Requires feed_type and filter_type
-         * @param {string} [channelId] Used when filter_type&#x3D;channel_id can be used to fetch all casts under a channel. Requires feed_type and filter_type
+         * @param {string} [channelId] Used when filter_type&#x3D;channel_id can be used to fetch casts under a channel. Requires feed_type and filter_type.
+         * @param {boolean} [membersOnly] Used when filter_type&#x3D;channel_id. Only include casts from members of the channel. True by default.
          * @param {string} [embedUrl] Used when filter_type&#x3D;embed_url can be used to fetch all casts with an embed url that contains embed_url. Requires feed_type and filter_type
          * @param {Array<EmbedType>} [embedTypes] Used when filter_type&#x3D;embed_types can be used to fetch all casts with matching content types. Requires feed_type and filter_type
          * @param {boolean} [withRecasts] Include recasts in the response, true by default
@@ -64,7 +65,7 @@ export const FeedApiAxiosParamCreator = function (configuration?: Configuration)
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        feed: async (apiKey: string, feedType: FeedType, filterType?: FilterType, fid?: number, fids?: string, parentUrl?: string, channelId?: string, embedUrl?: string, embedTypes?: Array<EmbedType>, withRecasts?: boolean, limit?: number, cursor?: string, viewerFid?: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        feed: async (apiKey: string, feedType: FeedType, filterType?: FilterType, fid?: number, fids?: string, parentUrl?: string, channelId?: string, membersOnly?: boolean, embedUrl?: string, embedTypes?: Array<EmbedType>, withRecasts?: boolean, limit?: number, cursor?: string, viewerFid?: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'apiKey' is not null or undefined
             assertParamExists('feed', 'apiKey', apiKey)
             // verify required parameter 'feedType' is not null or undefined
@@ -103,6 +104,10 @@ export const FeedApiAxiosParamCreator = function (configuration?: Configuration)
 
             if (channelId !== undefined) {
                 localVarQueryParameter['channel_id'] = channelId;
+            }
+
+            if (membersOnly !== undefined) {
+                localVarQueryParameter['members_only'] = membersOnly;
             }
 
             if (embedUrl !== undefined) {
@@ -152,13 +157,14 @@ export const FeedApiAxiosParamCreator = function (configuration?: Configuration)
          * @param {boolean} [withRecasts] Include recasts in the response, true by default
          * @param {number} [viewerFid] Providing this will return a feed that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {boolean} [withReplies] Include replies in the response, false by default
+         * @param {boolean} [membersOnly] Only include casts from members of the channel. True by default.
          * @param {number} [limit] Number of results to retrieve (default 25, max 100)
          * @param {string} [cursor] Pagination cursor.
          * @param {boolean} [shouldModerate] If true, only casts that have been liked by the moderator (if one exists) will be returned.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        feedChannels: async (apiKey: string, channelIds: string, withRecasts?: boolean, viewerFid?: number, withReplies?: boolean, limit?: number, cursor?: string, shouldModerate?: boolean, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        feedChannels: async (apiKey: string, channelIds: string, withRecasts?: boolean, viewerFid?: number, withReplies?: boolean, membersOnly?: boolean, limit?: number, cursor?: string, shouldModerate?: boolean, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'apiKey' is not null or undefined
             assertParamExists('feedChannels', 'apiKey', apiKey)
             // verify required parameter 'channelIds' is not null or undefined
@@ -189,6 +195,10 @@ export const FeedApiAxiosParamCreator = function (configuration?: Configuration)
 
             if (withReplies !== undefined) {
                 localVarQueryParameter['with_replies'] = withReplies;
+            }
+
+            if (membersOnly !== undefined) {
+                localVarQueryParameter['members_only'] = membersOnly;
             }
 
             if (limit !== undefined) {
@@ -750,7 +760,8 @@ export const FeedApiFp = function(configuration?: Configuration) {
          * @param {number} [fid] (Optional) fid of user whose feed you want to create. By default, the API expects this field, except if you pass a filter_type
          * @param {string} [fids] Used when filter_type&#x3D;fids . Create a feed based on a list of fids. Max array size is 250. Requires feed_type and filter_type.
          * @param {string} [parentUrl] Used when filter_type&#x3D;parent_url can be used to fetch content under any parent url e.g. FIP-2 channels on Warpcast. Requires feed_type and filter_type
-         * @param {string} [channelId] Used when filter_type&#x3D;channel_id can be used to fetch all casts under a channel. Requires feed_type and filter_type
+         * @param {string} [channelId] Used when filter_type&#x3D;channel_id can be used to fetch casts under a channel. Requires feed_type and filter_type.
+         * @param {boolean} [membersOnly] Used when filter_type&#x3D;channel_id. Only include casts from members of the channel. True by default.
          * @param {string} [embedUrl] Used when filter_type&#x3D;embed_url can be used to fetch all casts with an embed url that contains embed_url. Requires feed_type and filter_type
          * @param {Array<EmbedType>} [embedTypes] Used when filter_type&#x3D;embed_types can be used to fetch all casts with matching content types. Requires feed_type and filter_type
          * @param {boolean} [withRecasts] Include recasts in the response, true by default
@@ -760,8 +771,8 @@ export const FeedApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async feed(apiKey: string, feedType: FeedType, filterType?: FilterType, fid?: number, fids?: string, parentUrl?: string, channelId?: string, embedUrl?: string, embedTypes?: Array<EmbedType>, withRecasts?: boolean, limit?: number, cursor?: string, viewerFid?: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<FeedResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.feed(apiKey, feedType, filterType, fid, fids, parentUrl, channelId, embedUrl, embedTypes, withRecasts, limit, cursor, viewerFid, options);
+        async feed(apiKey: string, feedType: FeedType, filterType?: FilterType, fid?: number, fids?: string, parentUrl?: string, channelId?: string, membersOnly?: boolean, embedUrl?: string, embedTypes?: Array<EmbedType>, withRecasts?: boolean, limit?: number, cursor?: string, viewerFid?: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<FeedResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.feed(apiKey, feedType, filterType, fid, fids, parentUrl, channelId, membersOnly, embedUrl, embedTypes, withRecasts, limit, cursor, viewerFid, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -772,14 +783,15 @@ export const FeedApiFp = function(configuration?: Configuration) {
          * @param {boolean} [withRecasts] Include recasts in the response, true by default
          * @param {number} [viewerFid] Providing this will return a feed that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {boolean} [withReplies] Include replies in the response, false by default
+         * @param {boolean} [membersOnly] Only include casts from members of the channel. True by default.
          * @param {number} [limit] Number of results to retrieve (default 25, max 100)
          * @param {string} [cursor] Pagination cursor.
          * @param {boolean} [shouldModerate] If true, only casts that have been liked by the moderator (if one exists) will be returned.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async feedChannels(apiKey: string, channelIds: string, withRecasts?: boolean, viewerFid?: number, withReplies?: boolean, limit?: number, cursor?: string, shouldModerate?: boolean, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<FeedResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.feedChannels(apiKey, channelIds, withRecasts, viewerFid, withReplies, limit, cursor, shouldModerate, options);
+        async feedChannels(apiKey: string, channelIds: string, withRecasts?: boolean, viewerFid?: number, withReplies?: boolean, membersOnly?: boolean, limit?: number, cursor?: string, shouldModerate?: boolean, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<FeedResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.feedChannels(apiKey, channelIds, withRecasts, viewerFid, withReplies, membersOnly, limit, cursor, shouldModerate, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -930,7 +942,8 @@ export const FeedApiFactory = function (configuration?: Configuration, basePath?
          * @param {number} [fid] (Optional) fid of user whose feed you want to create. By default, the API expects this field, except if you pass a filter_type
          * @param {string} [fids] Used when filter_type&#x3D;fids . Create a feed based on a list of fids. Max array size is 250. Requires feed_type and filter_type.
          * @param {string} [parentUrl] Used when filter_type&#x3D;parent_url can be used to fetch content under any parent url e.g. FIP-2 channels on Warpcast. Requires feed_type and filter_type
-         * @param {string} [channelId] Used when filter_type&#x3D;channel_id can be used to fetch all casts under a channel. Requires feed_type and filter_type
+         * @param {string} [channelId] Used when filter_type&#x3D;channel_id can be used to fetch casts under a channel. Requires feed_type and filter_type.
+         * @param {boolean} [membersOnly] Used when filter_type&#x3D;channel_id. Only include casts from members of the channel. True by default.
          * @param {string} [embedUrl] Used when filter_type&#x3D;embed_url can be used to fetch all casts with an embed url that contains embed_url. Requires feed_type and filter_type
          * @param {Array<EmbedType>} [embedTypes] Used when filter_type&#x3D;embed_types can be used to fetch all casts with matching content types. Requires feed_type and filter_type
          * @param {boolean} [withRecasts] Include recasts in the response, true by default
@@ -940,8 +953,8 @@ export const FeedApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        feed(apiKey: string, feedType: FeedType, filterType?: FilterType, fid?: number, fids?: string, parentUrl?: string, channelId?: string, embedUrl?: string, embedTypes?: Array<EmbedType>, withRecasts?: boolean, limit?: number, cursor?: string, viewerFid?: number, options?: any): AxiosPromise<FeedResponse> {
-            return localVarFp.feed(apiKey, feedType, filterType, fid, fids, parentUrl, channelId, embedUrl, embedTypes, withRecasts, limit, cursor, viewerFid, options).then((request) => request(axios, basePath));
+        feed(apiKey: string, feedType: FeedType, filterType?: FilterType, fid?: number, fids?: string, parentUrl?: string, channelId?: string, membersOnly?: boolean, embedUrl?: string, embedTypes?: Array<EmbedType>, withRecasts?: boolean, limit?: number, cursor?: string, viewerFid?: number, options?: any): AxiosPromise<FeedResponse> {
+            return localVarFp.feed(apiKey, feedType, filterType, fid, fids, parentUrl, channelId, membersOnly, embedUrl, embedTypes, withRecasts, limit, cursor, viewerFid, options).then((request) => request(axios, basePath));
         },
         /**
          * Retrieve feed based on channel ids
@@ -951,14 +964,15 @@ export const FeedApiFactory = function (configuration?: Configuration, basePath?
          * @param {boolean} [withRecasts] Include recasts in the response, true by default
          * @param {number} [viewerFid] Providing this will return a feed that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {boolean} [withReplies] Include replies in the response, false by default
+         * @param {boolean} [membersOnly] Only include casts from members of the channel. True by default.
          * @param {number} [limit] Number of results to retrieve (default 25, max 100)
          * @param {string} [cursor] Pagination cursor.
          * @param {boolean} [shouldModerate] If true, only casts that have been liked by the moderator (if one exists) will be returned.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        feedChannels(apiKey: string, channelIds: string, withRecasts?: boolean, viewerFid?: number, withReplies?: boolean, limit?: number, cursor?: string, shouldModerate?: boolean, options?: any): AxiosPromise<FeedResponse> {
-            return localVarFp.feedChannels(apiKey, channelIds, withRecasts, viewerFid, withReplies, limit, cursor, shouldModerate, options).then((request) => request(axios, basePath));
+        feedChannels(apiKey: string, channelIds: string, withRecasts?: boolean, viewerFid?: number, withReplies?: boolean, membersOnly?: boolean, limit?: number, cursor?: string, shouldModerate?: boolean, options?: any): AxiosPromise<FeedResponse> {
+            return localVarFp.feedChannels(apiKey, channelIds, withRecasts, viewerFid, withReplies, membersOnly, limit, cursor, shouldModerate, options).then((request) => request(axios, basePath));
         },
         /**
          * Retrieve feed based on who a user is following
@@ -1100,7 +1114,8 @@ export class FeedApi extends BaseAPI {
      * @param {number} [fid] (Optional) fid of user whose feed you want to create. By default, the API expects this field, except if you pass a filter_type
      * @param {string} [fids] Used when filter_type&#x3D;fids . Create a feed based on a list of fids. Max array size is 250. Requires feed_type and filter_type.
      * @param {string} [parentUrl] Used when filter_type&#x3D;parent_url can be used to fetch content under any parent url e.g. FIP-2 channels on Warpcast. Requires feed_type and filter_type
-     * @param {string} [channelId] Used when filter_type&#x3D;channel_id can be used to fetch all casts under a channel. Requires feed_type and filter_type
+     * @param {string} [channelId] Used when filter_type&#x3D;channel_id can be used to fetch casts under a channel. Requires feed_type and filter_type.
+     * @param {boolean} [membersOnly] Used when filter_type&#x3D;channel_id. Only include casts from members of the channel. True by default.
      * @param {string} [embedUrl] Used when filter_type&#x3D;embed_url can be used to fetch all casts with an embed url that contains embed_url. Requires feed_type and filter_type
      * @param {Array<EmbedType>} [embedTypes] Used when filter_type&#x3D;embed_types can be used to fetch all casts with matching content types. Requires feed_type and filter_type
      * @param {boolean} [withRecasts] Include recasts in the response, true by default
@@ -1111,8 +1126,8 @@ export class FeedApi extends BaseAPI {
      * @throws {RequiredError}
      * @memberof FeedApi
      */
-    public feed(apiKey: string, feedType: FeedType, filterType?: FilterType, fid?: number, fids?: string, parentUrl?: string, channelId?: string, embedUrl?: string, embedTypes?: Array<EmbedType>, withRecasts?: boolean, limit?: number, cursor?: string, viewerFid?: number, options?: AxiosRequestConfig) {
-        return FeedApiFp(this.configuration).feed(apiKey, feedType, filterType, fid, fids, parentUrl, channelId, embedUrl, embedTypes, withRecasts, limit, cursor, viewerFid, options).then((request) => request(this.axios, this.basePath));
+    public feed(apiKey: string, feedType: FeedType, filterType?: FilterType, fid?: number, fids?: string, parentUrl?: string, channelId?: string, membersOnly?: boolean, embedUrl?: string, embedTypes?: Array<EmbedType>, withRecasts?: boolean, limit?: number, cursor?: string, viewerFid?: number, options?: AxiosRequestConfig) {
+        return FeedApiFp(this.configuration).feed(apiKey, feedType, filterType, fid, fids, parentUrl, channelId, membersOnly, embedUrl, embedTypes, withRecasts, limit, cursor, viewerFid, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -1123,6 +1138,7 @@ export class FeedApi extends BaseAPI {
      * @param {boolean} [withRecasts] Include recasts in the response, true by default
      * @param {number} [viewerFid] Providing this will return a feed that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
      * @param {boolean} [withReplies] Include replies in the response, false by default
+     * @param {boolean} [membersOnly] Only include casts from members of the channel. True by default.
      * @param {number} [limit] Number of results to retrieve (default 25, max 100)
      * @param {string} [cursor] Pagination cursor.
      * @param {boolean} [shouldModerate] If true, only casts that have been liked by the moderator (if one exists) will be returned.
@@ -1130,8 +1146,8 @@ export class FeedApi extends BaseAPI {
      * @throws {RequiredError}
      * @memberof FeedApi
      */
-    public feedChannels(apiKey: string, channelIds: string, withRecasts?: boolean, viewerFid?: number, withReplies?: boolean, limit?: number, cursor?: string, shouldModerate?: boolean, options?: AxiosRequestConfig) {
-        return FeedApiFp(this.configuration).feedChannels(apiKey, channelIds, withRecasts, viewerFid, withReplies, limit, cursor, shouldModerate, options).then((request) => request(this.axios, this.basePath));
+    public feedChannels(apiKey: string, channelIds: string, withRecasts?: boolean, viewerFid?: number, withReplies?: boolean, membersOnly?: boolean, limit?: number, cursor?: string, shouldModerate?: boolean, options?: AxiosRequestConfig) {
+        return FeedApiFp(this.configuration).feedChannels(apiKey, channelIds, withRecasts, viewerFid, withReplies, membersOnly, limit, cursor, shouldModerate, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**


### PR DESCRIPTION
## Overview

This adds the `membersOnly` parameter to `fetchFeed` and `fetchFeedByChannelIds`.

## Examples

### `fetchFeed`

```
# index.js
    const result = await client.fetchFeed("filter", {limit: 3, filterType: "channel_id", channelId: "farcaster"});
    console.log(JSON.stringify(result));
```

```
$ node index.js | jq '.casts[] | {
  "text": .text,
  "username": .author.username,
}'
{
  "text": "0. A thought\n1. Go to place\n2. Vibe check\n3. Yap\n\n0 to 1 was untrained. Retrain",
  "username": "na"
}
{
  "text": "PSA for /farcaster\n\nGoing to start pruning members of this channel. \n\nIf you're cast is off-topic, going to remove you. No warning.\n\nWill have a new direction later this week.\n\nhttps://warpcast.com/dwr.eth/0x395a5753",
  "username": "dwr.eth"
}
{
  "text": "Don't confuse this with Farcaster is irrelevant to drive business results!\n\nHappy to walk you through Farcater for your business. Comment below and I'll help you",
  "username": "samuellhuber.eth"
}
```

### `fetchFeedByChannelIds`

```
# index.js
    const result = await client.fetchFeedByChannelIds(["farcaster"], {limit: 3});
    console.log(JSON.stringify(result));
```

```
$  node index.js | jq '.casts[] | {
  "text": .text,
  "username": .author.username,
}'
{
  "text": "0. A thought\n1. Go to place\n2. Vibe check\n3. Yap\n\n0 to 1 was untrained. Retrain",
  "username": "na"
}
{
  "text": "PSA for /farcaster\n\nGoing to start pruning members of this channel. \n\nIf you're cast is off-topic, going to remove you. No warning.\n\nWill have a new direction later this week.\n\nhttps://warpcast.com/dwr.eth/0x395a5753",
  "username": "dwr.eth"
}
{
  "text": "Don't confuse this with Farcaster is irrelevant to drive business results!\n\nHappy to walk you through Farcater for your business. Comment below and I'll help you",
  "username": "samuellhuber.eth"
}
```