### PR TITLE
types: remove 'ChannelMember.channel_id' in favor of 'ChannelMember.channel.id'

### DIFF
--- a/src/neynar-api/v2/openapi-farcaster/models/channel-member-list-response.ts
+++ b/src/neynar-api/v2/openapi-farcaster/models/channel-member-list-response.ts
@@ -37,6 +37,6 @@ export interface ChannelMemberListResponse {
      * @type {NextCursor}
      * @memberof ChannelMemberListResponse
      */
-    'next'?: NextCursor;
+    'next': NextCursor;
 }
 

--- a/src/neynar-api/v2/openapi-farcaster/models/channel-member.ts
+++ b/src/neynar-api/v2/openapi-farcaster/models/channel-member.ts
@@ -36,12 +36,6 @@ export interface ChannelMember {
      */
     'object': ChannelMemberObjectEnum;
     /**
-     * The unique identifier of a farcaster channel
-     * @type {string}
-     * @memberof ChannelMember
-     */
-    'channel_id': string;
-    /**
      * 
      * @type {ChannelMemberRole}
      * @memberof ChannelMember


### PR DESCRIPTION
- Removes `ChannelMember`'s field `channel_id` in favor of `ChannelMember`'s `channel.id`
- Also pulls in an update specifying `next` as required in `ChannelMemberListResponse`