### PR TITLE
feat: add 'fold' option to lookupCastConversation()

### DIFF
--- a/src/neynar-api/neynar-api-client.ts
+++ b/src/neynar-api/neynar-api-client.ts
@@ -1385,7 +1385,7 @@ export class NeynarAPIClient {
    *    fold: 'above',
    *    viewerFid: 3,
    *    limit: 2,
-   *    cursor: "{{nextPageCursor}}"
+   *    // cursor: "{{nextPageCursor}}"
    * }).then(response => {
    *   console.log('Subsequent casts in conversation above the fold', response.conversation.cast.direct_replies);
    * });

--- a/src/neynar-api/neynar-api-client.ts
+++ b/src/neynar-api/neynar-api-client.ts
@@ -1340,6 +1340,7 @@ export class NeynarAPIClient {
    * @param {boolean} [options.includeChronologicalParentCasts] - An optional parameter within the options object, indicating whether to include chronological parent casts in the response. This parameter is useful for applications requiring a structured view of the conversation, including parent casts that provide context for the replies.
    * @param {number} [options.viewerFid] - Providing this will return a conversation that respects this user's mutes and blocks and includes `viewer_context`.
    * @param {CastConversationSortType} [options.sortType] - Optional parameter to modify the sort type. (default 'desc_chron')
+   * @param {'above' | 'below'} [options.fold] - Optional parameter to add a fold to the conversation. When not specified, all casts are returned. When specified, only the casts above or below the fold are returned.
    * @param {number} [options.limit] - Number of results to retrieve (default 20, max 50).
    * @param {string} [options.cursor] - Pagination cursor for fetching specific subsets of results.
    *  Omit this parameter for the initial request.
@@ -1357,6 +1358,53 @@ export class NeynarAPIClient {
    *   console.log('Cast Conversation Information:', response); // Displays the detailed structure of the specified cast conversation
    * });
    *
+   * 
+   * @example
+   * // Implement above and below 'the fold', generally seen in clients as "show more replies".
+   * // Fetch first page above the fold:
+   * client.lookupCastConversation(
+   *   'https://warpcast.com/rish/0x9288c1',
+   *   CastParamType.Url,
+   *  { 
+   *    replyDepth: 2,
+   *    includeChronologicalParentCasts: true,
+   *    fold: 'above',
+   *    viewerFid: 3,
+   *    limit: 2,
+   *    // cursor: "nextPageCursor" // Omit this parameter for the initial request
+   * }).then(response => {
+   *   console.log('Cast Conversation Information:', response); // Outputs detailed information about the specified cast conversation
+   * });
+   * // Subsequent pages above the fold
+   * client.lookupCastConversation(
+   *   'https://warpcast.com/rish/0x9288c1',
+   *   CastParamType.Url,
+   *  { 
+   *    replyDepth: 2,
+   *    includeChronologicalParentCasts: false,
+   *    fold: 'above',
+   *    viewerFid: 3,
+   *    limit: 2,
+   *    cursor: "{{nextPageCursor}}"
+   * }).then(response => {
+   *   console.log('Subsequent casts in conversation above the fold', response.conversation.cast.direct_replies);
+   * });
+   * // Fetch below the fold on "show more replies" click
+   * client.lookupCastConversation(
+   *   'https://warpcast.com/rish/0x9288c1',
+   *   CastParamType.Url,
+   *  { 
+   *    replyDepth: 2,
+   *    includeChronologicalParentCasts: false,
+   *    fold: 'below',
+   *    viewerFid: 3,
+   *    limit: 2,
+   *    // cursor: "{{nextPageCursor}}" // Omit for the first request
+   * }).then(response => {
+   *   console.log('Casts from below the fold:', response.conversation.cast.direct_replies);
+   * });
+   * 
+   * 
    * // Refer to the Neynar API documentation for more details and advanced options:
    * // https://docs.neynar.com/reference/cast-conversation
    */
@@ -1368,6 +1416,7 @@ export class NeynarAPIClient {
       includeChronologicalParentCasts?: boolean;
       viewerFid?: number;
       sortType?: CastConversationSortType;
+      fold?: 'above' | 'below';
       limit?: number;
       cursor?: string;
     }

--- a/src/neynar-api/v2/client.ts
+++ b/src/neynar-api/v2/client.ts
@@ -1143,6 +1143,7 @@ export class NeynarV2APIClient {
    * @param {boolean} [options.includeChronologicalParentCasts] - Optional parameter to include chronological parent casts in the response.
    * @param {number} [options.viewerFid] - Providing this will return a conversation that respects this user's mutes and blocks and includes `viewer_context`.
    * @param {CastConversationSortType} [options.sortType] - Optional parameter to modify the sort type. (default 'desc_chron')
+   * @param {'above' | 'below'} [options.fold] - Optional parameter to add a fold to the conversation. When not specified, all casts are returned. When specified, only the casts above or below the fold are returned.
    * @param {number} [options.limit] - Number of results to retrieve (default 20, max 50)
    * @param {string} [options.cursor] - Optional parameter to specify the pagination cursor for fetching specific subsets of results.
    * @returns {Promise<Conversation>} A promise that resolves to a `Conversation` object,
@@ -1158,6 +1159,51 @@ export class NeynarV2APIClient {
    *   console.log('Cast Conversation Information:', response); // Outputs detailed information about the specified cast conversation
    * });
    *
+   * @example
+   * // Implement above and below 'the fold', generally seen in clients as "show more replies".
+   * // Fetch first page above the fold:
+   * client.lookupCastConversation(
+   *   'https://warpcast.com/rish/0x9288c1',
+   *   CastParamType.Url,
+   *  { 
+   *    replyDepth: 2,
+   *    includeChronologicalParentCasts: true,
+   *    fold: 'above',
+   *    viewerFid: 3,
+   *    limit: 2,
+   *    // cursor: "nextPageCursor" // Omit this parameter for the initial request
+   * }).then(response => {
+   *   console.log('Cast Conversation Information:', response); // Outputs detailed information about the specified cast conversation
+   * });
+   * // Subsequent pages above the fold
+   * client.lookupCastConversation(
+   *   'https://warpcast.com/rish/0x9288c1',
+   *   CastParamType.Url,
+   *  { 
+   *    replyDepth: 2,
+   *    includeChronologicalParentCasts: false,
+   *    fold: 'above',
+   *    viewerFid: 3,
+   *    limit: 2,
+   *    cursor: "{{nextPageCursor}}"
+   * }).then(response => {
+   *   console.log('Subsequent casts in conversation above the fold', response.conversation.cast.direct_replies);
+   * });
+   * // Fetch below the fold on "show more replies" click
+   * client.lookupCastConversation(
+   *   'https://warpcast.com/rish/0x9288c1',
+   *   CastParamType.Url,
+   *  { 
+   *    replyDepth: 2,
+   *    includeChronologicalParentCasts: false,
+   *    fold: 'below',
+   *    viewerFid: 3,
+   *    limit: 2,
+   *    // cursor: "{{nextPageCursor}}" // Omit for the first request
+   * }).then(response => {
+   *   console.log('Casts from below the fold:', response.conversation.cast.direct_replies);
+   * });
+   * 
    * For more information, refer to the [Neynar documentation](https://docs.neynar.com/reference/cast-conversation).
    */
   public async lookupCastConversation(
@@ -1168,6 +1214,7 @@ export class NeynarV2APIClient {
       includeChronologicalParentCasts?: boolean;
       viewerFid?: number;
       sortType?: CastConversationSortType;
+      fold? : 'above' | 'below';
       limit?: number;
       cursor?: string;
     }
@@ -1180,6 +1227,7 @@ export class NeynarV2APIClient {
       options?.includeChronologicalParentCasts,
       options?.viewerFid,
       options?.sortType,
+      options?.fold,
       options?.limit,
       options?.cursor
     );

--- a/src/neynar-api/v2/client.ts
+++ b/src/neynar-api/v2/client.ts
@@ -1185,7 +1185,7 @@ export class NeynarV2APIClient {
    *    fold: 'above',
    *    viewerFid: 3,
    *    limit: 2,
-   *    cursor: "{{nextPageCursor}}"
+   *    // cursor: "{{nextPageCursor}}"
    * }).then(response => {
    *   console.log('Subsequent casts in conversation above the fold', response.conversation.cast.direct_replies);
    * });

--- a/src/neynar-api/v2/openapi-farcaster/apis/cast-api.ts
+++ b/src/neynar-api/v2/openapi-farcaster/apis/cast-api.ts
@@ -119,12 +119,13 @@ export const CastApiAxiosParamCreator = function (configuration?: Configuration)
          * @param {boolean} [includeChronologicalParentCasts] Include all parent casts in chronological order
          * @param {number} [viewerFid] Providing this will return a conversation that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {CastConversationSortType} [sortType] Sort type for the ordering of descendants. Default is &#x60;desc_chron&#x60;
+         * @param {'above' | 'below'} [fold] Show conversation above or below the fold. Lower quality responses are hidden below the fold. Not passing in a value shows the full conversation without any folding.
          * @param {number} [limit] Number of results to retrieve (default 20, max 50)
          * @param {string} [cursor] Pagination cursor.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        castConversation: async (apiKey: string, identifier: string, type: CastParamType, replyDepth?: number, includeChronologicalParentCasts?: boolean, viewerFid?: number, sortType?: CastConversationSortType, limit?: number, cursor?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        castConversation: async (apiKey: string, identifier: string, type: CastParamType, replyDepth?: number, includeChronologicalParentCasts?: boolean, viewerFid?: number, sortType?: CastConversationSortType, fold?: 'above' | 'below', limit?: number, cursor?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'apiKey' is not null or undefined
             assertParamExists('castConversation', 'apiKey', apiKey)
             // verify required parameter 'identifier' is not null or undefined
@@ -165,6 +166,10 @@ export const CastApiAxiosParamCreator = function (configuration?: Configuration)
 
             if (sortType !== undefined) {
                 localVarQueryParameter['sort_type'] = sortType;
+            }
+
+            if (fold !== undefined) {
+                localVarQueryParameter['fold'] = fold;
             }
 
             if (limit !== undefined) {
@@ -497,13 +502,14 @@ export const CastApiFp = function(configuration?: Configuration) {
          * @param {boolean} [includeChronologicalParentCasts] Include all parent casts in chronological order
          * @param {number} [viewerFid] Providing this will return a conversation that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {CastConversationSortType} [sortType] Sort type for the ordering of descendants. Default is &#x60;desc_chron&#x60;
+         * @param {'above' | 'below'} [fold] Show conversation above or below the fold. Lower quality responses are hidden below the fold. Not passing in a value shows the full conversation without any folding.
          * @param {number} [limit] Number of results to retrieve (default 20, max 50)
          * @param {string} [cursor] Pagination cursor.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async castConversation(apiKey: string, identifier: string, type: CastParamType, replyDepth?: number, includeChronologicalParentCasts?: boolean, viewerFid?: number, sortType?: CastConversationSortType, limit?: number, cursor?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Conversation>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.castConversation(apiKey, identifier, type, replyDepth, includeChronologicalParentCasts, viewerFid, sortType, limit, cursor, options);
+        async castConversation(apiKey: string, identifier: string, type: CastParamType, replyDepth?: number, includeChronologicalParentCasts?: boolean, viewerFid?: number, sortType?: CastConversationSortType, fold?: 'above' | 'below', limit?: number, cursor?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Conversation>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.castConversation(apiKey, identifier, type, replyDepth, includeChronologicalParentCasts, viewerFid, sortType, fold, limit, cursor, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -610,13 +616,14 @@ export const CastApiFactory = function (configuration?: Configuration, basePath?
          * @param {boolean} [includeChronologicalParentCasts] Include all parent casts in chronological order
          * @param {number} [viewerFid] Providing this will return a conversation that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
          * @param {CastConversationSortType} [sortType] Sort type for the ordering of descendants. Default is &#x60;desc_chron&#x60;
+         * @param {'above' | 'below'} [fold] Show conversation above or below the fold. Lower quality responses are hidden below the fold. Not passing in a value shows the full conversation without any folding.
          * @param {number} [limit] Number of results to retrieve (default 20, max 50)
          * @param {string} [cursor] Pagination cursor.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        castConversation(apiKey: string, identifier: string, type: CastParamType, replyDepth?: number, includeChronologicalParentCasts?: boolean, viewerFid?: number, sortType?: CastConversationSortType, limit?: number, cursor?: string, options?: any): AxiosPromise<Conversation> {
-            return localVarFp.castConversation(apiKey, identifier, type, replyDepth, includeChronologicalParentCasts, viewerFid, sortType, limit, cursor, options).then((request) => request(axios, basePath));
+        castConversation(apiKey: string, identifier: string, type: CastParamType, replyDepth?: number, includeChronologicalParentCasts?: boolean, viewerFid?: number, sortType?: CastConversationSortType, fold?: 'above' | 'below', limit?: number, cursor?: string, options?: any): AxiosPromise<Conversation> {
+            return localVarFp.castConversation(apiKey, identifier, type, replyDepth, includeChronologicalParentCasts, viewerFid, sortType, fold, limit, cursor, options).then((request) => request(axios, basePath));
         },
         /**
          * Search for casts based on a query string, with optional AND filters
@@ -719,14 +726,15 @@ export class CastApi extends BaseAPI {
      * @param {boolean} [includeChronologicalParentCasts] Include all parent casts in chronological order
      * @param {number} [viewerFid] Providing this will return a conversation that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
      * @param {CastConversationSortType} [sortType] Sort type for the ordering of descendants. Default is &#x60;desc_chron&#x60;
+     * @param {'above' | 'below'} [fold] Show conversation above or below the fold. Lower quality responses are hidden below the fold. Not passing in a value shows the full conversation without any folding.
      * @param {number} [limit] Number of results to retrieve (default 20, max 50)
      * @param {string} [cursor] Pagination cursor.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof CastApi
      */
-    public castConversation(apiKey: string, identifier: string, type: CastParamType, replyDepth?: number, includeChronologicalParentCasts?: boolean, viewerFid?: number, sortType?: CastConversationSortType, limit?: number, cursor?: string, options?: AxiosRequestConfig) {
-        return CastApiFp(this.configuration).castConversation(apiKey, identifier, type, replyDepth, includeChronologicalParentCasts, viewerFid, sortType, limit, cursor, options).then((request) => request(this.axios, this.basePath));
+    public castConversation(apiKey: string, identifier: string, type: CastParamType, replyDepth?: number, includeChronologicalParentCasts?: boolean, viewerFid?: number, sortType?: CastConversationSortType, fold?: 'above' | 'below', limit?: number, cursor?: string, options?: AxiosRequestConfig) {
+        return CastApiFp(this.configuration).castConversation(apiKey, identifier, type, replyDepth, includeChronologicalParentCasts, viewerFid, sortType, fold, limit, cursor, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**


### PR DESCRIPTION
Adds the `fold` option to `lookupCastConversation` alongside an extensive example of how to implement functionality like "more replies"

```javascript
// Implement above and below 'the fold', generally seen in clients as "show more replies".
// Fetch first page above the fold:
client.lookupCastConversation(
  'https://warpcast.com/rish/0x9288c1',
  CastParamType.Url,
 { 
   replyDepth: 2,
   includeChronologicalParentCasts: true,
   fold: 'above',
   viewerFid: 3,
   limit: 2,
   // cursor: "nextPageCursor" // Omit this parameter for the initial request
}).then(response => {
  console.log('Cast Conversation Information:', response); // Outputs detailed information about the specified cast conversation
});
// Subsequent pages above the fold
client.lookupCastConversation(
  'https://warpcast.com/rish/0x9288c1',
  CastParamType.Url,
 { 
   replyDepth: 2,
   includeChronologicalParentCasts: false,
   fold: 'above',
   viewerFid: 3,
   limit: 2,
   cursor: "{{nextPageCursor}}"
}).then(response => {
  console.log('Subsequent casts in conversation above the fold', response.conversation.cast.direct_replies);
});
// Fetch below the fold on "show more replies" click
client.lookupCastConversation(
  'https://warpcast.com/rish/0x9288c1',
  CastParamType.Url,
{ 
   replyDepth: 2,
   includeChronologicalParentCasts: false,
   fold: 'below',
   viewerFid: 3,
   limit: 2,
   // cursor: "{{nextPageCursor}}" // Omit for the first request
}).then(response => {
  console.log('Casts from below the fold:', response.conversation.cast.direct_replies);
});
```
