### PR TITLE
feat: add 'chron' sort type to lookupCastConversation

### DIFF
--- a/src/neynar-api/neynar-api-client.ts
+++ b/src/neynar-api/neynar-api-client.ts
@@ -1341,7 +1341,7 @@ export class NeynarAPIClient {
    * @param {number} [options.replyDepth] - An optional parameter within the options object, specifying the desired depth of replies to fetch within the conversation. This allows for tailored retrieval of conversation data, ranging from top-level casts only to deeper, more comprehensive conversation threads.
    * @param {boolean} [options.includeChronologicalParentCasts] - An optional parameter within the options object, indicating whether to include chronological parent casts in the response. This parameter is useful for applications requiring a structured view of the conversation, including parent casts that provide context for the replies.
    * @param {number} [options.viewerFid] - Providing this will return a conversation that respects this user's mutes and blocks and includes `viewer_context`.
-   * @param {CastConversationSortType} [options.sortType] - Optional parameter to modify the sort type. (default 'desc_chron')
+   * @param {CastConversationSortType} [options.sortType] - Optional parameter to modify the sort type. (default 'chron')
    * @param {'above' | 'below'} [options.fold] - Optional parameter to add a fold to the conversation. When not specified, all casts are returned. When specified, only the casts above or below the fold are returned.
    * @param {number} [options.limit] - Number of results to retrieve (default 20, max 50).
    * @param {string} [options.cursor] - Pagination cursor for fetching specific subsets of results.

--- a/src/neynar-api/v2/client.ts
+++ b/src/neynar-api/v2/client.ts
@@ -1148,7 +1148,7 @@ export class NeynarV2APIClient {
    * @param {number} [options.replyDepth] - Optional parameter to specify how deep the reply chain should be fetched.
    * @param {boolean} [options.includeChronologicalParentCasts] - Optional parameter to include chronological parent casts in the response.
    * @param {number} [options.viewerFid] - Providing this will return a conversation that respects this user's mutes and blocks and includes `viewer_context`.
-   * @param {CastConversationSortType} [options.sortType] - Optional parameter to modify the sort type. (default 'desc_chron')
+   * @param {CastConversationSortType} [options.sortType] - Optional parameter to modify the sort type. (default 'chron')
    * @param {'above' | 'below'} [options.fold] - Optional parameter to add a fold to the conversation. When not specified, all casts are returned. When specified, only the casts above or below the fold are returned.
    * @param {number} [options.limit] - Number of results to retrieve (default 20, max 50)
    * @param {string} [options.cursor] - Optional parameter to specify the pagination cursor for fetching specific subsets of results.

--- a/src/neynar-api/v2/openapi-farcaster/apis/cast-api.ts
+++ b/src/neynar-api/v2/openapi-farcaster/apis/cast-api.ts
@@ -118,7 +118,7 @@ export const CastApiAxiosParamCreator = function (configuration?: Configuration)
          * @param {number} [replyDepth] The depth of replies in the conversation that will be returned (default 2)
          * @param {boolean} [includeChronologicalParentCasts] Include all parent casts in chronological order
          * @param {number} [viewerFid] Providing this will return a conversation that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
-         * @param {CastConversationSortType} [sortType] Sort type for the ordering of descendants. Default is &#x60;desc_chron&#x60;
+         * @param {CastConversationSortType} [sortType] Sort type for the ordering of descendants. Default is &#x60;chron&#x60;
          * @param {'above' | 'below'} [fold] Show conversation above or below the fold. Lower quality responses are hidden below the fold. Not passing in a value shows the full conversation without any folding.
          * @param {number} [limit] Number of results to retrieve (default 20, max 50)
          * @param {string} [cursor] Pagination cursor.
@@ -501,7 +501,7 @@ export const CastApiFp = function(configuration?: Configuration) {
          * @param {number} [replyDepth] The depth of replies in the conversation that will be returned (default 2)
          * @param {boolean} [includeChronologicalParentCasts] Include all parent casts in chronological order
          * @param {number} [viewerFid] Providing this will return a conversation that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
-         * @param {CastConversationSortType} [sortType] Sort type for the ordering of descendants. Default is &#x60;desc_chron&#x60;
+         * @param {CastConversationSortType} [sortType] Sort type for the ordering of descendants. Default is &#x60;chron&#x60;
          * @param {'above' | 'below'} [fold] Show conversation above or below the fold. Lower quality responses are hidden below the fold. Not passing in a value shows the full conversation without any folding.
          * @param {number} [limit] Number of results to retrieve (default 20, max 50)
          * @param {string} [cursor] Pagination cursor.
@@ -615,7 +615,7 @@ export const CastApiFactory = function (configuration?: Configuration, basePath?
          * @param {number} [replyDepth] The depth of replies in the conversation that will be returned (default 2)
          * @param {boolean} [includeChronologicalParentCasts] Include all parent casts in chronological order
          * @param {number} [viewerFid] Providing this will return a conversation that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
-         * @param {CastConversationSortType} [sortType] Sort type for the ordering of descendants. Default is &#x60;desc_chron&#x60;
+         * @param {CastConversationSortType} [sortType] Sort type for the ordering of descendants. Default is &#x60;chron&#x60;
          * @param {'above' | 'below'} [fold] Show conversation above or below the fold. Lower quality responses are hidden below the fold. Not passing in a value shows the full conversation without any folding.
          * @param {number} [limit] Number of results to retrieve (default 20, max 50)
          * @param {string} [cursor] Pagination cursor.
@@ -725,7 +725,7 @@ export class CastApi extends BaseAPI {
      * @param {number} [replyDepth] The depth of replies in the conversation that will be returned (default 2)
      * @param {boolean} [includeChronologicalParentCasts] Include all parent casts in chronological order
      * @param {number} [viewerFid] Providing this will return a conversation that respects this user\&#39;s mutes and blocks and includes &#x60;viewer_context&#x60;.
-     * @param {CastConversationSortType} [sortType] Sort type for the ordering of descendants. Default is &#x60;desc_chron&#x60;
+     * @param {CastConversationSortType} [sortType] Sort type for the ordering of descendants. Default is &#x60;chron&#x60;
      * @param {'above' | 'below'} [fold] Show conversation above or below the fold. Lower quality responses are hidden below the fold. Not passing in a value shows the full conversation without any folding.
      * @param {number} [limit] Number of results to retrieve (default 20, max 50)
      * @param {string} [cursor] Pagination cursor.

--- a/src/neynar-api/v2/openapi-farcaster/models/cast-conversation-sort-type.ts
+++ b/src/neynar-api/v2/openapi-farcaster/models/cast-conversation-sort-type.ts
@@ -21,6 +21,7 @@
  */
 
 export const CastConversationSortType = {
+    Chron: 'chron',
     DescChron: 'desc_chron',
     Algorithmic: 'algorithmic'
 } as const;


### PR DESCRIPTION
- feat: add 'chron' sort type to 'lookupCastConversation'
- fix: 'desc_chron' sort type is actually reverse chronological now
- docs: update 'lookupCastConversation' sort type default to 'chron'