### PR TITLE
Docs: Added snippet on where/how to import type definitions from

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,19 @@ Please refer to our [Getting Started Guide](https://docs.neynar.com/reference/ge
 
 Checkout [examples](https://github.com/neynarxyz/farcaster-examples) using this SDK
 
+## Type Definitions
+
+You can directly import the type definitions from the SDK as shown below:
+
+- See your `node_modules/@neynar/nodejs-sdk/build/neynar-api/v2/openapi-farcaster` directory for the type definitions.
+
+```typescript
+import { type User } from '@neynar/nodejs-sdk/build/neynar-api/v2/openapi-farcaster/models/user'
+import { type CastAuthor } from '@neynar/nodejs-sdk/build/neynar-api/v2/openapi-farcaster/models/cast-author'
+import { type CastWithInteractionsReactions } from '@neynar/nodejs-sdk/build/neynar-api/v2/openapi-farcaster/models/cast-with-interactions-reactions'
+
+```
+
 ## Contribution Guidelines
 
 see [CONTRIBUTING.md](./CONTRIBUTING.md).


### PR DESCRIPTION
I was so bummed out when I didn't know how to import just the type definitions of objects from responses from the Neynar functions. 

I didn't know it was even possible, I had to make my own type definition from scratch based on the responses and what my IDE was telling me was in 'CastAuthor' etc.

I dug a little bit and found out that you CAN in fact import the type definitions which has been super helpful.

Really wished this was explicitly shown somewhere, I imagine this will help a ton of people that want to directly use type definitions directly from neynar instead of serializing or using custom type definitions.

Added to README:

...
## Type Definitions

You can directly import the type definitions from the SDK as shown below:

- See your `node_modules/@neynar/nodejs-sdk/build/neynar-api/v2/openapi-farcaster` directory for the type definitions.

```typescript
import { type User } from '@neynar/nodejs-sdk/build/neynar-api/v2/openapi-farcaster/models/user'
import { type CastAuthor } from '@neynar/nodejs-sdk/build/neynar-api/v2/openapi-farcaster/models/cast-author'
import { type CastWithInteractionsReactions } from '@neynar/nodejs-sdk/build/neynar-api/v2/openapi-farcaster/models/cast-with-interactions-reactions'

```
...