### PR TITLE
Publish v1 version with dist-tag for npm (needs to go after v2 is released)

### DIFF
--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -1,9 +1,11 @@
-name: "Publish to npm 🚀"
+name: "Publish v1 to npm 🚀"
 
 on:
   push:
     branches:
       - v1
+    paths:
+      - src/neynar-api/common/version.ts
 
 jobs:
   build:
@@ -27,5 +29,5 @@ jobs:
       - name: Set npm Config
         run: npm config set //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}
 
-      - name: Publish to npm
-        run: npm publish --access public
+      - name: Publish v1 to npm with 'v1' tag
+        run: npm publish --tag v1 --access public


### PR DESCRIPTION

This PR configures the publishing process for version 1 of the @neynar/nodejs-sdk package. It ensures that v1 releases are properly tagged with v1 on npm, allowing users to continue using v1 while ensuring the latest version of the SDK (v2) is the default installation for new users.
