### PR TITLE
Update webhooks.ts

### DIFF
--- a/src/types/webhooks.ts
+++ b/src/types/webhooks.ts
@@ -54,7 +54,12 @@ export interface WebhookCastCreated {
   data: Cast;
   type: "cast.created";
   created_at: number;
-  event_timestamp: string;
+}
+
+export interface WebhookCastDeleted {
+  data: Cast;
+  type: "cast.deleted";
+  created_at: number;
 }
 
 export interface WebhookUserCreated {


### PR DESCRIPTION
datatypes don't match what's coming through on the Event Delivery Details and castDeleted was missing entirely. A lot of the data doesn't match either with fields like "deprecation_notice" and "target" missing from reactionCreated.