### PR TITLE
fix: include type-fest dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "axios": "^1.14.0",
     "semver": "^7.6.3",
+    "type-fest": "^0.21.3",
     "viem": "^2.21.44"
   },
   "devDependencies": {


### PR DESCRIPTION
Adds `type-fest` to runtime dependencies. The generated declarations import `SetRequired` from it, so consumers need the package available when TypeScript resolves the SDK types.

Tested with `yarn build`.